### PR TITLE
feat: atualiza documentação e migra para Material for MkDocs

### DIFF
--- a/docs/estudos/backend/index.md
+++ b/docs/estudos/backend/index.md
@@ -1,19 +1,24 @@
 # Backend
 
-Esta seção reúne os estudos, conceitos, tecnologias e decisões relacionadas ao desenvolvimento backend do sistema.
+Esta seção reúne os estudos, definições e tecnologias relacionadas ao desenvolvimento backend da plataforma LegisKids.
 
-Aqui estão documentados os fundamentos da arquitetura backend, APIs, banco de dados, autenticação, servidores, hospedagem e stacks tecnológicas utilizadas no projeto.
+O backend é responsável pelo processamento das informações legislativas, integração com APIs públicas, organização dos dados e comunicação com o banco de dados da aplicação.
+
+---
 
 ## Objetivos
 
-- Estudar os fundamentos do desenvolvimento backend
+- Definir a arquitetura backend do sistema
 - Documentar tecnologias e stacks utilizadas
-- Definir padrões de arquitetura do sistema
-- Organizar conteúdos sobre APIs, banco de dados e autenticação
-- Garantir escalabilidade, segurança e manutenção do backend
+- Estruturar padrões de organização e desenvolvimento
+- Garantir escalabilidade, segurança e manutenção
+- Centralizar estudos relacionados ao processamento de dados e APIs
 
-# Conteúdo
+---
 
-- [Estudo de Stack Back-End](estudo_stack_backend_definida.md)
-- [Comparação de Stacks Back-End](comparacao_stacks_backend.md)
-- [Estudo de Tecnologias Back-End](estudo_tecnologias_backend.md)
+## Conteúdo
+
+- [Estudo de Stack Backend](estudo_stack_backend_definida.md)
+- [Comparação de Stacks Backend](comparacao_stacks_backend.md)
+- [Estudo de Tecnologias Backend](estudo_tecnologias_backend.md)
+

--- a/docs/estudos/sdd/index.md
+++ b/docs/estudos/sdd/index.md
@@ -1,0 +1,20 @@
+# SDD
+
+Esta seção reúne os estudos e documentos relacionados ao Software Design Description (SDD) da plataforma LegisKids.
+
+O SDD descreve a organização estrutural do sistema, seus componentes, responsabilidades e integrações.
+
+---
+
+## Objetivos
+
+- Documentar a arquitetura do sistema
+- Descrever componentes e responsabilidades
+- Centralizar definições estruturais
+- Facilitar manutenção e evolução da aplicação
+
+---
+
+## Conteúdo
+
+- [Estudo SDD](sddEstudo.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,37 +4,159 @@ site_author: Equipe do Projeto
 site_url: https://unb-mds.github.io/2026-1-LegisKids/
 
 theme:
-  name: mkdocs
+  name: material
+
+  language: pt-BR
+
+  palette:
+
+    - scheme: default
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/weather-night
+        name: Alternar para modo escuro
+
+    - scheme: slate
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/weather-sunny
+        name: Alternar para modo claro
+
+  font:
+    text: Roboto
+    code: JetBrains Mono
+
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.footer
+    - navigation.indexes
+    - toc.follow
+    - toc.integrate
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.tabs.link
+
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+
+  - toc:
+      permalink: true
+
+  - pymdownx.details
+  - pymdownx.superfences
+
+  - pymdownx.highlight:
+      anchor_linenums: true
+
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/unb-mds/2026-1-LegisKids
 
 nav:
 
   - Home: index.md
 
-  - Projeto: projeto/index.md
+  - Projeto:
+      - Visão Geral: projeto/index.md
+      - Ideia do Projeto: projeto/ideia_escolhida_projeto.md
 
-  - Arquitetura: estudos/arquitetura/index.md
+  - Arquitetura:
+      - Visão Geral: estudos/arquitetura/index.md
+      - Escolha da Arquitetura: estudos/arquitetura/escolha_arquitetura.md
+      - Tecnologias: estudos/arquitetura/checando_tecnologias.md
+      - Diagrama V1: estudos/arquitetura/diagrama_arquitetura_v1.md
+      - Diagrama V2: estudos/arquitetura/diagrama_arquitetura_v2.md
+      - Fluxo de Dados: estudos/arquitetura/estudo_fluxo_de_dados.md
+      - Login: estudos/arquitetura/estudo_login.md
+      - Estudo Inicial: estudos/arquitetura/estudo_arquiteturas.md
 
-  - Backend / API: estudos/API/index.md
+  - Backend:
+      - Visão Geral: estudos/backend/index.md
+      - Estudo de Stack Backend: estudos/backend/estudo_stack_backend_definida.md
+      - Comparação de Stacks: estudos/backend/comparacao_stacks_backend.md
+      - Tecnologias Backend: estudos/backend/estudo_tecnologias_backend.md
 
-  - Banco de Dados: estudos/banco_de_dados/index.md
+      - API:
+          - Visão Geral: estudos/API/index.md
+          - Levantamento de APIs: estudos/API/levantamento_api.md
 
-  - Frontend: estudos/frontend/index.md
+  - Banco de Dados:
+      - Visão Geral: estudos/banco_de_dados/index.md
+      - Definição Banco: estudos/banco_de_dados/definicao_banco_de_dados.md
+      - Definição de Dados: estudos/banco_de_dados/definicao_dados.md
+      - Definição de Tabelas: estudos/banco_de_dados/definicao_tabelas.md
+      - Estudo Banco: estudos/banco_de_dados/estudo_banco_de_dados.md
+      - Hospedagem: estudos/banco_de_dados/hospedagem_banco_de_dados.md
 
-  - Design: estudos/design/index.md
+  - Frontend:
+      - Visão Geral: estudos/frontend/index.md
+      - Tecnologias e Estrutura: estudos/frontend/tecnologias_estrutura.md
 
-  - Git / GitHub: estudos/git_github/index.md
+  - Design:
+      - Visão Geral: estudos/design/index.md
+      - Protótipo Interativo: estudos/design/prototipo_interativo.md
+      - Identidade Visual: estudos/design/identidade_visual.md
+      - Dashboards: estudos/design/definicao_dashboards.md
 
-  - Metodologia: estudos/metodos_ageis/index.md
+  - Git / GitHub:
+      - Visão Geral: estudos/git_github/index.md
+      - Estudo GitHub: estudos/git_github/estudo_github.md
+      - Labels de Issues: estudos/git_github/labels_tamanho_issue.md
 
-  - Gestão: reunioes/index.md
+  - Metodologia:
+      - Visão Geral: estudos/metodos_ageis/index.md
+      - Métodos Ágeis: estudos/metodos_ageis/metodos_ageis.md
 
-  - Padrão / Organização: padrao_organizacao/index.md
+  - Gestão:
+      - Visão Geral: reunioes/index.md
+      - Dailies: reunioes/dailies.md
+      - Horários: reunioes/horarios.md
+      - Reviews e Retrospectivas: reunioes/reviews_retrospectives.md
+      - Sprint Planning: reunioes/sprint_plannings.md
 
-  - Requisitos: estudos/requisitos/index.md
+  - Organização:
+      - Visão Geral: padrao_organizacao/index.md
+      - Organização Geral: padrao_organizacao/organizacao_geral.md
+      - Padrão Commits: padrao_organizacao/padrao_commits.md
+      - Padrão PR: padrao_organizacao/padrao_PR.md
+      - Padrão Kanban: padrao_organizacao/padrao_kanban.md
+      - Nome de Arquivos: padrao_organizacao/padrao_nomes_arquivos.md
 
-  - Inteligência Artificial: estudos/inteligencia_artificial/index.md
+  - Requisitos:
+      - Visão Geral: estudos/requisitos/index.md
+      - Requisitos de Software: estudos/requisitos/requisitos_de_software.md
+      - Documento Complementar: estudos/requisitos/estudo_requisitos_software.md
 
-  - Dashboard: performance/index.md
-  
-plugins:
-  - search
+  - Inteligência Artificial:
+      - Visão Geral: estudos/inteligencia_artificial/index.md
+      - Estudo IA: estudos/inteligencia_artificial/estudo_ia.md
+
+  - Dashboard:
+      - Visão Geral: performance/index.md
+
+  - SDD:
+      - Visão Geral: estudos/sdd/index.md
+      - Estudo SDD: estudos/sdd/sddEstudo.md


### PR DESCRIPTION
## Descrição

Este PR realiza a migração da documentação do projeto para o Material for MkDocs, além de reorganizar a estrutura de navegação e documentação técnica da plataforma.

Também foram adicionadas melhorias na organização dos estudos, definição de novas seções e refinamento visual da documentação.

## Alterações realizadas

* Migração do tema padrão para Material for MkDocs
* Reestruturação da navegação no `mkdocs.yml`
* Melhoria da organização das seções da documentação
* Criação da seção Backend
* Organização da API como subcategoria de Backend
* Adição da seção SDD
* Atualização e padronização de páginas `index.md`
* Melhoria visual e estrutural da documentação

## Resultado esperado

* Navegação mais organizada
* Melhor experiência de leitura
* Estrutura documental mais escalável
* Interface mais moderna e profissional
* Melhor integração entre as seções técnicas do projeto
