### PR TITLE
[docs] #166 - padroniza requirements na raiz do projeto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.95
+uvicorn>=0.22
+SQLAlchemy>=1.4
+passlib[bcrypt]>=1.7
+PyJWT>=2.0
+pytest  


### PR DESCRIPTION
## O que foi feito?

* Adição de um `requirements.txt` na raiz do projeto
* Padronização da instalação de dependências Python

## Por que isso foi feito?

* Facilitar o processo de instalação do projeto
* Melhorar organização das dependências
* Seguir convenções comuns de projetos Python

## Como testar?

1. Clone o repositório
2. Crie um ambiente virtual Python
3. Execute:

```bash
pip install -r requirements.txt
```

4. Verifique se as dependências são instaladas corretamente