### PR TITLE
[docs] #197 -  corrigi arquivo claude.md sobre o banco de dados

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ O agente **não deve iniciar nenhuma implementação sem que a spec da mudança 
 
 **IA:** considerar custo de chamadas, modularidade, possibilidade de fallback e facilidade de troca futura do modelo.
 
-**Banco:** evitar schemas excessivamente complexos, manter modelagem relacional limpa e consistência dos dados.
+**Banco:** evitar schemas excessivamente complexos, manter modelagem relacional limpa e consistência dos dados. O schema inclui a tabela `categorias` — uma proposição pode estar associada a uma ou várias categorias (relação muitos-para-muitos via tabela intermediária `proposicao_categorias`).
 
 ---
 


### PR DESCRIPTION
📌 O que foi feito?

- Atualizada a diretriz de Banco no CLAUDE.md para documentar a tabela categorias e sua relação muitos-para-muitos com proposicoes via tabela intermediária proposicao_categorias
- Adicionada entrada de memória persistente em .claude/projects/.../memory/ registrando o mesmo relacionamento para referência futura do agente

🎯 Por que isso foi feito?

- O schema do banco evoluiu com a tabela categorias, mas o CLAUDE.md não refletia essa estrutura
- Sem essa documentação, o agente poderia modelar o relacionamento incorretamente (ex: um-para-muitos em vez de muitos-para-muitos) ao implementar rotas, models ou queries

🧪 Como testar?

1. Abrir CLAUDE.md e localizar a seção Diretrizes Técnicas > Banco
2. Verificar que o texto menciona categorias e proposicao_categorias com relação muitos-para-muitos
3. Confirmar que .claude/projects/-home-luis-2026-1-Squad08/memory/project_db_categorias.md existe e descreve o relacionamento corretamente

📸 Prints/Vídeos (se houver)

N/A — alteração apenas em documentação

🔗 Issue relacionada

Closes #197 