### PR TITLE
[feat]#208-implementa-rotas-de-proposicoes-estatisticas-e-temas

### DIFF
--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/design.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/design.md
@@ -1,0 +1,62 @@
+## Context
+
+O frontend Vue 3 já está implementado e consumindo 4 endpoints REST. O backend Flask tem models, repository e service completos, mas zero rotas HTTP de leitura. O bloqueio é pura ausência de controller — os dados já existem no banco.
+
+**Estado atual do repositório** (métodos relevantes):
+- `get_ids_existentes`, `get_proposicoes_pendentes`, `upsert_proposicoes_lote` — voltados para ETL
+- `get_ultimas_execucoes(limite)` — retorna SyncExecucoes; serve para achar o último sync bem-sucedido
+- Nenhum método de listagem, detalhe ou agregação para a API de leitura
+
+**Gaps de dados descobertos na análise do frontend:**
+1. `proposicoes` não tem coluna `autor`/`nome_autor` — o frontend tem fallback para null; retornar campo ausente.
+2. `proposicoes` não tem coluna `url_documento`/`url` — idem, fallback visual no frontend.
+3. O frontend lê `status` mas o banco tem `descricao_situacao` — resolver com alias na serialização.
+4. O frontend lê `subtema`/`categoria` (string) mas o banco tem `categorias` (array) — retornar o nome da primeira categoria como `subtema`.
+5. Tramitações: frontend lê `data`, `descricao`, `orgao`; banco tem `data_hora`, `descricao_tramitacao`, `sigla_orgao` — adicionar aliases no dict.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implementar `GET /api/proposicoes`, `GET /api/proposicoes/<id>`, `GET /api/estatisticas`, `GET /api/temas` com respostas que o frontend atual já interpreta corretamente.
+- Adicionar métodos de leitura no repositório para não escrever SQL no controller.
+- Todos os erros retornam JSON `{"error": "..."}` com status HTTP adequado.
+
+**Non-Goals:**
+- Autenticação / autorização (Release 2).
+- Modificar `camara_service.py` ou `camara_scheduler.py`.
+- Migrações de banco — nenhuma coluna nova.
+- Endpoints de escrita (POST/PUT/DELETE).
+
+## Decisions
+
+**D1 — Blueprint Flask separado**
+`controllers/proposicoes_controller.py` exporta `proposicoes_bp`. Registrado em `app.py` com uma linha. Alternativa (rotas inline em app.py) rejeitada por falta de separação.
+
+**D2 — Aliases de campo na serialização, não nos models**
+`Proposicao.to_dict()` permanece inalterado. O controller cria um dict derivado adicionando `status`, `subtema`, `nome_autor` etc. Alternativa (alterar `to_dict()`) rejeitada porque quebraria a consistência interna usada pelo service/scheduler.
+
+**D3 — Queries de agregação no repositório, não no controller**
+Métodos novos em `camara_repository.py`: `listar_proposicoes_paginado`, `get_proposicao_detalhe`, `get_estatisticas_dashboard`, `listar_categorias_com_total`. Controller chama o repositório, nunca `db.session` diretamente.
+
+**D4 — Filtro por subtema via JOIN em proposicao_categoria**
+`subtema` no query param filtra por `Categoria.nome`. Exige JOIN; feito com SQLAlchemy (sem SQL raw).
+
+**D5 — Lazy loading explícito para tramitações na rota de detalhe**
+A rota de detalhe carrega `prop.tramitacoes.all()` explicitamente. A rota de lista NÃO carrega tramitações (evita N+1).
+
+## Risks / Trade-offs
+
+**[N+1 nas categorias na lista]** → Mitigado pela paginação (máx. 50 itens/página) e `joinedload` nas categorias.
+
+**[Dados sem autor]** → Frontend já tem fallback para 'Não informado'; campo ausente na resposta é aceitável para R1.
+
+**[`url_documento` inexistente]** → Seção de link no DetalheView não renderiza se o campo for null; sem impacto visual crítico para R1.
+
+**[Estatísticas com banco vazio]** → Contagens retornam 0, listas retornam vazias; frontend mostra '—' nos cards.
+
+## Migration Plan
+
+1. Criar `src/backend/controllers/proposicoes_controller.py`
+2. Adicionar métodos de leitura em `src/backend/repository/camara_repository.py`
+3. Adicionar duas linhas em `src/backend/app.py` (import + register_blueprint)
+4. Rollback: remover as duas linhas de app.py e o arquivo do controller (sem efeito no banco)

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/proposal.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+O frontend Vue já consome 4 endpoints REST (`/api/proposicoes`, `/api/proposicoes/<id>`, `/api/estatisticas`, `/api/temas`) que simplesmente não existem no Flask — toda requisição retorna 404. Isso bloqueia a Release 1, com entrega prevista para quarta-feira (2026-07-01).
+
+## What Changes
+
+- Novo arquivo `src/backend/controllers/proposicoes_controller.py` com um Blueprint Flask registrando as 4 rotas.
+- Novos métodos no `src/backend/repository/camara_repository.py` para queries que o controller precisa mas o repositório ainda não tem: listagem paginada com filtros, detalhe por ID, contagens por categoria e por mês, e último sync bem-sucedido.
+- Registro do blueprint em `src/backend/app.py` (uma linha).
+
+## Capabilities
+
+### New Capabilities
+
+- `api-proposicoes-list`: `GET /api/proposicoes` — listagem paginada com filtros (q, parlamentar, partido, data_inicio, data_fim, subtema, pagina, por_pagina); retorna `{items, total, pagina, total_paginas}`.
+- `api-proposicoes-detail`: `GET /api/proposicoes/<int:id>` — detalhe completo com categorias e tramitações; retorna `{proposicao, tramitacoes}` ou 404.
+- `api-estatisticas`: `GET /api/estatisticas` — métricas para o dashboard; retorna `{resumo, ultima_atualizacao, por_subtema, por_status, temporal}`.
+- `api-temas`: `GET /api/temas` — lista de categorias com total de proposições vinculadas; retorna array de objetos.
+
+### Modified Capabilities
+
+*(nenhuma — nenhum endpoint existente é alterado)*
+
+## Impact
+
+- **Backend:** novo controller + métodos novos no repositório; `camara_service.py` e `camara_scheduler.py` não são tocados.
+- **Frontend:** zero mudanças — os services já apontam para as URLs corretas.
+- **Banco:** queries apenas de leitura (SELECT); sem migrações.
+- **CORS:** `app.py` já permite `localhost:5173`; nenhuma mudança necessária.
+- **Deploy (Vercel):** o frontend é estático; o backend Flask precisará de configuração de variáveis de ambiente (`DATABASE_URL`) no ambiente de produção.

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-estatisticas/spec.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-estatisticas/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Estatísticas para o dashboard
+O sistema SHALL expor `GET /api/estatisticas` retornando métricas agregadas para alimentar os widgets e gráficos do DashboardView. A resposta SHALL conter `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status` e `temporal`.
+
+#### Scenario: Estrutura completa da resposta
+- **WHEN** cliente faz `GET /api/estatisticas`
+- **THEN** sistema retorna HTTP 200 com objeto contendo todas as 5 chaves: `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status`, `temporal`
+
+#### Scenario: Resumo com contagens gerais
+- **WHEN** sistema processa a rota
+- **THEN** `resumo` SHALL conter: `total` (COUNT todas as proposições), `ativas` (COUNT onde descricao_situacao = 'Em tramitação'), `subtemas` (COUNT categorias distintas vinculadas a pelo menos uma proposição), `alertas` (retornar 0 — feature de R2)
+
+#### Scenario: Data do último sync bem-sucedido
+- **WHEN** existem sync_executions com status 'concluido' ou 'concluido_parcial'
+- **THEN** `ultima_atualizacao` SHALL ser o `finalizado_em` do sync mais recente bem-sucedido (ISO 8601)
+
+#### Scenario: Sem syncs bem-sucedidos
+- **WHEN** não há sync_executions com status de sucesso
+- **THEN** `ultima_atualizacao` SHALL ser null
+
+#### Scenario: Distribuição por subtema para gráfico de barras
+- **WHEN** sistema processa por_subtema
+- **THEN** SHALL retornar `{ labels: [array de nomes de categorias], values: [array de contagens] }` com pares posicionalmente alinhados, ordenado por contagem DESC
+
+#### Scenario: Distribuição por status para gráfico de pizza
+- **WHEN** sistema processa por_status
+- **THEN** SHALL retornar `{ labels: [array de descricao_situacao distintas], values: [array de contagens] }` com todas as proposições cobertos
+
+#### Scenario: Evolução temporal para gráfico de linha
+- **WHEN** sistema processa temporal
+- **THEN** SHALL retornar `{ labels: [array de strings "MMM/YYYY" ex: "Jan/2024"], values: [array de contagens] }` agrupado por mês de data_apresentacao, ordenado ASC
+
+#### Scenario: Banco sem dados
+- **WHEN** tabela proposicoes está vazia
+- **THEN** `resumo.total` é 0; `por_subtema`, `por_status`, `temporal` retornam `{ labels: [], values: [] }`

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-proposicoes-detail/spec.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-proposicoes-detail/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Detalhe completo de proposição
+O sistema SHALL expor `GET /api/proposicoes/<int:id>` retornando todos os dados de uma proposição, incluindo categorias e histórico de tramitação. A resposta SHALL ter a forma `{ proposicao: {...}, tramitacoes: [...] }`.
+
+#### Scenario: Proposição encontrada
+- **WHEN** cliente faz `GET /api/proposicoes/123` e proposição 123 existe
+- **THEN** sistema retorna HTTP 200 com `proposicao` contendo todos os campos e `tramitacoes` ordenadas cronologicamente
+
+#### Scenario: Campos obrigatórios na proposição
+- **WHEN** sistema retorna a proposição
+- **THEN** o objeto SHALL conter: `id`, `ementa`, `sigla_tipo`, `numero`, `ano`, `data_apresentacao`, `descricao_situacao`, `status` (alias), `sigla_partido`, `partido`, `categorias`, `subtema` (nome da primeira categoria ou null), `classificacao_status`
+
+#### Scenario: Tramitações com aliases compatíveis com frontend
+- **WHEN** sistema retorna tramitações
+- **THEN** cada tramitação SHALL conter: `data_hora`, `data` (alias de data_hora), `descricao_tramitacao`, `descricao` (alias), `sigla_orgao`, `orgao` (alias), `descricao_situacao`, `id_situacao`; ordenadas por `data_hora` ASC
+
+#### Scenario: Proposição sem tramitações
+- **WHEN** proposição não tem tramitações registradas
+- **THEN** sistema retorna `tramitacoes: []`
+
+#### Scenario: Proposição não encontrada
+- **WHEN** cliente faz `GET /api/proposicoes/99999` e proposição não existe
+- **THEN** sistema retorna HTTP 404 com `{"error": "Proposição não encontrada"}`

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-proposicoes-list/spec.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-proposicoes-list/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Listagem paginada de proposições
+O sistema SHALL expor `GET /api/proposicoes` retornando proposições paginadas com suporte a filtros opcionais. A resposta SHALL ter a forma `{ items: [...], total: int, pagina: int, total_paginas: int }`.
+
+#### Scenario: Requisição sem filtros retorna primeira página
+- **WHEN** cliente faz `GET /api/proposicoes`
+- **THEN** sistema retorna HTTP 200 com `items` (até 10 proposições), `total` (contagem total), `pagina: 1`, `total_paginas` calculado
+
+#### Scenario: Paginação via query params
+- **WHEN** cliente faz `GET /api/proposicoes?pagina=2&por_pagina=25`
+- **THEN** sistema retorna a segunda página com até 25 itens; `pagina` na resposta é 2
+
+#### Scenario: Busca textual via parâmetro q
+- **WHEN** cliente faz `GET /api/proposicoes?q=cyberbullying`
+- **THEN** sistema retorna apenas proposições cuja `ementa` contém "cyberbullying" (case-insensitive, match parcial)
+
+#### Scenario: Filtro por partido
+- **WHEN** cliente faz `GET /api/proposicoes?partido=PT`
+- **THEN** sistema retorna apenas proposições cuja `sigla_partido` é "PT" (case-insensitive)
+
+#### Scenario: Filtro por subtema (categoria)
+- **WHEN** cliente faz `GET /api/proposicoes?subtema=cyberbullying`
+- **THEN** sistema retorna apenas proposições vinculadas à categoria "cyberbullying"
+
+#### Scenario: Filtro por intervalo de datas
+- **WHEN** cliente faz `GET /api/proposicoes?data_inicio=2024-01-01&data_fim=2024-12-31`
+- **THEN** sistema retorna apenas proposições com `data_apresentacao` dentro do intervalo
+
+#### Scenario: Filtros combinados
+- **WHEN** cliente faz `GET /api/proposicoes?q=criança&partido=PT&subtema=cyberbullying`
+- **THEN** sistema aplica todos os filtros conjuntamente (AND)
+
+#### Scenario: Campos obrigatórios em cada item da lista
+- **WHEN** sistema retorna items na lista
+- **THEN** cada item SHALL conter: `id`, `ementa`, `data_apresentacao`, `sigla_partido`, `descricao_situacao`, `status` (alias de descricao_situacao), `subtema` (nome da primeira categoria ou null), `categorias` (array)
+
+#### Scenario: Resultado vazio
+- **WHEN** nenhuma proposição corresponde aos filtros
+- **THEN** sistema retorna HTTP 200 com `items: []` e `total: 0`
+
+### Requirement: Erros retornam JSON
+O sistema SHALL retornar erros como JSON `{"error": "mensagem"}` com status HTTP adequado, nunca HTML.
+
+#### Scenario: Parâmetro inválido
+- **WHEN** cliente envia `pagina=abc` (não numérico)
+- **THEN** sistema retorna HTTP 400 com `{"error": "pagina deve ser um inteiro positivo"}`

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-temas/spec.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/specs/api-temas/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Listagem de temas (categorias) com totais
+O sistema SHALL expor `GET /api/temas` retornando todas as categorias ativas com o total de proposições vinculadas a cada uma. A resposta SHALL ser um array JSON.
+
+#### Scenario: Lista de temas com contagens
+- **WHEN** cliente faz `GET /api/temas`
+- **THEN** sistema retorna HTTP 200 com array de objetos, cada um contendo: `id`, `nome`, `descricao`, `cor`, `icone`, `ativa`, `total` (número de proposições vinculadas)
+
+#### Scenario: Ordenação por total DESC
+- **WHEN** sistema retorna os temas
+- **THEN** lista SHALL ser ordenada por `total` decrescente (temas com mais proposições primeiro)
+
+#### Scenario: Tema sem proposições
+- **WHEN** uma categoria existe mas não tem proposições vinculadas
+- **THEN** esse tema aparece na lista com `total: 0`
+
+#### Scenario: Banco sem categorias
+- **WHEN** tabela categorias está vazia
+- **THEN** sistema retorna HTTP 200 com array vazio `[]`

--- a/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/tasks.md
+++ b/openspec/changes/archive/2026-06-29-flask-api-routes-proposicoes/tasks.md
@@ -1,0 +1,27 @@
+## 1. Repositório — métodos de leitura
+
+- [x] 1.1 Adicionar `listar_proposicoes_paginado(filtros, pagina, por_pagina)` em `camara_repository.py`: query com filtros opcionais (q ILIKE, partido, data_inicio, data_fim, subtema via JOIN), retorna `(items: list[Proposicao], total: int)`
+- [x] 1.2 Adicionar `get_proposicao_detalhe(id)` em `camara_repository.py`: busca proposição por PK com tramitações (eager load ou `.all()` explícito), retorna `Proposicao | None`
+- [x] 1.3 Adicionar `get_estatisticas_dashboard()` em `camara_repository.py`: retorna dict com `total`, `ativas`, `subtemas`, `por_subtema`, `por_status`, `temporal`, `ultima_atualizacao`
+- [x] 1.4 Adicionar `listar_categorias_com_total()` em `camara_repository.py`: retorna lista de dicts com campos de Categoria + `total` (contagem de proposições vinculadas), ordenado por total DESC
+
+## 2. Controller Flask
+
+- [x] 2.1 Criar `src/backend/controllers/proposicoes_controller.py` com `proposicoes_bp = Blueprint('proposicoes', __name__)`
+- [x] 2.2 Implementar `GET /api/proposicoes`: ler query params (pagina, por_pagina, q, parlamentar, partido, data_inicio, data_fim, subtema), chamar `listar_proposicoes_paginado`, serializar com aliases (`status`, `subtema`, `nome_autor`)
+- [x] 2.3 Implementar `GET /api/proposicoes/<int:id>`: chamar `get_proposicao_detalhe`, serializar proposição com aliases + tramitações com aliases (data, descricao, orgao); retornar 404 se não encontrar
+- [x] 2.4 Implementar `GET /api/estatisticas`: chamar `get_estatisticas_dashboard`, retornar dict no formato `{resumo, ultima_atualizacao, por_subtema, por_status, temporal}`
+- [x] 2.5 Implementar `GET /api/temas`: chamar `listar_categorias_com_total`, retornar array JSON
+- [x] 2.6 Adicionar handler de erro genérico no blueprint para retornar `{"error": "..."}` em vez de HTML
+
+## 3. Registro do blueprint em app.py
+
+- [x] 3.1 Adicionar `from src.backend.controllers.proposicoes_controller import proposicoes_bp` e `app.register_blueprint(proposicoes_bp)` em `src/backend/app.py` (após `db.init_app(app)`)
+
+## 4. Verificação manual das rotas
+
+- [x] 4.1 Iniciar `flask run` e confirmar que `GET /api/temas` retorna array de categorias com campo `total`
+- [x] 4.2 Confirmar que `GET /api/proposicoes` retorna `{items, total, pagina, total_paginas}`
+- [x] 4.3 Confirmar que `GET /api/proposicoes/<id>` retorna `{proposicao, tramitacoes}` (ou 404 para ID inválido)
+- [x] 4.4 Confirmar que `GET /api/estatisticas` retorna todas as 5 chaves: `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status`, `temporal`
+- [x] 4.5 Confirmar que uma requisição a ID inexistente retorna `{"error": "..."}` com status 404 (não HTML)

--- a/openspec/specs/api-estatisticas/spec.md
+++ b/openspec/specs/api-estatisticas/spec.md
@@ -1,0 +1,53 @@
+# Spec: api-estatisticas
+
+## Objetivo
+
+Definir o endpoint `GET /api/estatisticas` do backend Flask, fornecendo métricas agregadas para o DashboardView.
+
+## Contexto
+
+O frontend (DashboardView) chama esta rota ao montar e distribui os dados para os cards de resumo e três gráficos Chart.js: barras (por_subtema), pizza (por_status) e linha (temporal). Implementado em `src/backend/controllers/proposicoes_controller.py`; delegado a `get_estatisticas_dashboard` no repositório.
+
+## Escopo
+
+- Resposta obrigatória: `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status`, `temporal`
+- `alertas` fixo em 0 (feature de R2)
+- `temporal` agrupado por mês/ano com labels "MMM/YYYY" em português
+- `ultima_atualizacao` derivado de `sync_executions` com status de sucesso
+
+## Requisitos
+
+### Requirement: Estatísticas para o dashboard
+O sistema SHALL expor `GET /api/estatisticas` retornando métricas agregadas para alimentar os widgets e gráficos do DashboardView. A resposta SHALL conter `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status` e `temporal`.
+
+#### Scenario: Estrutura completa da resposta
+- **WHEN** cliente faz `GET /api/estatisticas`
+- **THEN** sistema retorna HTTP 200 com objeto contendo todas as 5 chaves: `resumo`, `ultima_atualizacao`, `por_subtema`, `por_status`, `temporal`
+
+#### Scenario: Resumo com contagens gerais
+- **WHEN** sistema processa a rota
+- **THEN** `resumo` SHALL conter: `total` (COUNT todas as proposições), `ativas` (COUNT onde descricao_situacao = 'Em tramitação'), `subtemas` (COUNT categorias distintas vinculadas a pelo menos uma proposição), `alertas` (retornar 0 — feature de R2)
+
+#### Scenario: Data do último sync bem-sucedido
+- **WHEN** existem sync_executions com status 'concluido' ou 'concluido_parcial'
+- **THEN** `ultima_atualizacao` SHALL ser o `finalizado_em` do sync mais recente bem-sucedido (ISO 8601)
+
+#### Scenario: Sem syncs bem-sucedidos
+- **WHEN** não há sync_executions com status de sucesso
+- **THEN** `ultima_atualizacao` SHALL ser null
+
+#### Scenario: Distribuição por subtema para gráfico de barras
+- **WHEN** sistema processa por_subtema
+- **THEN** SHALL retornar `{ labels: [array de nomes de categorias], values: [array de contagens] }` com pares posicionalmente alinhados, ordenado por contagem DESC
+
+#### Scenario: Distribuição por status para gráfico de pizza
+- **WHEN** sistema processa por_status
+- **THEN** SHALL retornar `{ labels: [array de descricao_situacao distintas], values: [array de contagens] }` com todas as proposições cobertos
+
+#### Scenario: Evolução temporal para gráfico de linha
+- **WHEN** sistema processa temporal
+- **THEN** SHALL retornar `{ labels: [array de strings "MMM/YYYY" ex: "Jan/2024"], values: [array de contagens] }` agrupado por mês de data_apresentacao, ordenado ASC
+
+#### Scenario: Banco sem dados
+- **WHEN** tabela proposicoes está vazia
+- **THEN** `resumo.total` é 0; `por_subtema`, `por_status`, `temporal` retornam `{ labels: [], values: [] }`

--- a/openspec/specs/api-proposicoes-detail/spec.md
+++ b/openspec/specs/api-proposicoes-detail/spec.md
@@ -1,0 +1,41 @@
+# Spec: api-proposicoes-detail
+
+## Objetivo
+
+Definir o endpoint `GET /api/proposicoes/<int:id>` do backend Flask, retornando dados completos de uma proposição incluindo categorias e histórico de tramitação.
+
+## Contexto
+
+O frontend (DetalheView) consome esta rota para exibir a página de detalhe. Implementado em `src/backend/controllers/proposicoes_controller.py`; delegado a `get_proposicao_detalhe` no repositório.
+
+## Escopo
+
+- Retorna `{ proposicao: {...}, tramitacoes: [...] }`
+- Tramitações ordenadas por `data_hora` ASC
+- Aliases de campo para compatibilidade com frontend: `status`, `subtema`, `nome_autor`, `data`, `descricao`, `orgao`
+- 404 com JSON se proposição não encontrada
+
+## Requisitos
+
+### Requirement: Detalhe completo de proposição
+O sistema SHALL expor `GET /api/proposicoes/<int:id>` retornando todos os dados de uma proposição, incluindo categorias e histórico de tramitação. A resposta SHALL ter a forma `{ proposicao: {...}, tramitacoes: [...] }`.
+
+#### Scenario: Proposição encontrada
+- **WHEN** cliente faz `GET /api/proposicoes/123` e proposição 123 existe
+- **THEN** sistema retorna HTTP 200 com `proposicao` contendo todos os campos e `tramitacoes` ordenadas cronologicamente
+
+#### Scenario: Campos obrigatórios na proposição
+- **WHEN** sistema retorna a proposição
+- **THEN** o objeto SHALL conter: `id`, `ementa`, `sigla_tipo`, `numero`, `ano`, `data_apresentacao`, `descricao_situacao`, `status` (alias), `sigla_partido`, `partido`, `categorias`, `subtema` (nome da primeira categoria ou null), `classificacao_status`
+
+#### Scenario: Tramitações com aliases compatíveis com frontend
+- **WHEN** sistema retorna tramitações
+- **THEN** cada tramitação SHALL conter: `data_hora`, `data` (alias de data_hora), `descricao_tramitacao`, `descricao` (alias), `sigla_orgao`, `orgao` (alias), `descricao_situacao`, `id_situacao`; ordenadas por `data_hora` ASC
+
+#### Scenario: Proposição sem tramitações
+- **WHEN** proposição não tem tramitações registradas
+- **THEN** sistema retorna `tramitacoes: []`
+
+#### Scenario: Proposição não encontrada
+- **WHEN** cliente faz `GET /api/proposicoes/99999` e proposição não existe
+- **THEN** sistema retorna HTTP 404 com `{"error": "Proposição não encontrada"}`

--- a/openspec/specs/api-proposicoes-list/spec.md
+++ b/openspec/specs/api-proposicoes-list/spec.md
@@ -1,0 +1,65 @@
+# Spec: api-proposicoes-list
+
+## Objetivo
+
+Definir o endpoint `GET /api/proposicoes` do backend Flask, responsável por retornar proposições paginadas com suporte a filtros combinados.
+
+## Contexto
+
+O frontend (BuscaView + useProposicoesStore) consome esta rota passando query params de paginação e filtros. A rota é implementada em `src/backend/controllers/proposicoes_controller.py` e delega a query a `listar_proposicoes_paginado` no repositório.
+
+## Escopo
+
+- Paginação via `pagina` e `por_pagina` (máx. 50)
+- Filtros: `q` (ementa ILIKE), `partido` (sigla_partido ILIKE), `data_inicio`, `data_fim`, `subtema` (via EXISTS em categorias)
+- Resposta: `{ items, total, pagina, total_paginas }`
+- Cada item inclui aliases `status` e `subtema` para compatibilidade com o frontend
+- Erros retornam JSON, nunca HTML
+
+## Requisitos
+
+### Requirement: Listagem paginada de proposições
+O sistema SHALL expor `GET /api/proposicoes` retornando proposições paginadas com suporte a filtros opcionais. A resposta SHALL ter a forma `{ items: [...], total: int, pagina: int, total_paginas: int }`.
+
+#### Scenario: Requisição sem filtros retorna primeira página
+- **WHEN** cliente faz `GET /api/proposicoes`
+- **THEN** sistema retorna HTTP 200 com `items` (até 10 proposições), `total` (contagem total), `pagina: 1`, `total_paginas` calculado
+
+#### Scenario: Paginação via query params
+- **WHEN** cliente faz `GET /api/proposicoes?pagina=2&por_pagina=25`
+- **THEN** sistema retorna a segunda página com até 25 itens; `pagina` na resposta é 2
+
+#### Scenario: Busca textual via parâmetro q
+- **WHEN** cliente faz `GET /api/proposicoes?q=cyberbullying`
+- **THEN** sistema retorna apenas proposições cuja `ementa` contém "cyberbullying" (case-insensitive, match parcial)
+
+#### Scenario: Filtro por partido
+- **WHEN** cliente faz `GET /api/proposicoes?partido=PT`
+- **THEN** sistema retorna apenas proposições cuja `sigla_partido` é "PT" (case-insensitive)
+
+#### Scenario: Filtro por subtema (categoria)
+- **WHEN** cliente faz `GET /api/proposicoes?subtema=cyberbullying`
+- **THEN** sistema retorna apenas proposições vinculadas à categoria "cyberbullying"
+
+#### Scenario: Filtro por intervalo de datas
+- **WHEN** cliente faz `GET /api/proposicoes?data_inicio=2024-01-01&data_fim=2024-12-31`
+- **THEN** sistema retorna apenas proposições com `data_apresentacao` dentro do intervalo
+
+#### Scenario: Filtros combinados
+- **WHEN** cliente faz `GET /api/proposicoes?q=criança&partido=PT&subtema=cyberbullying`
+- **THEN** sistema aplica todos os filtros conjuntamente (AND)
+
+#### Scenario: Campos obrigatórios em cada item da lista
+- **WHEN** sistema retorna items na lista
+- **THEN** cada item SHALL conter: `id`, `ementa`, `data_apresentacao`, `sigla_partido`, `descricao_situacao`, `status` (alias de descricao_situacao), `subtema` (nome da primeira categoria ou null), `categorias` (array)
+
+#### Scenario: Resultado vazio
+- **WHEN** nenhuma proposição corresponde aos filtros
+- **THEN** sistema retorna HTTP 200 com `items: []` e `total: 0`
+
+### Requirement: Erros retornam JSON
+O sistema SHALL retornar erros como JSON `{"error": "mensagem"}` com status HTTP adequado, nunca HTML.
+
+#### Scenario: Parâmetro inválido
+- **WHEN** cliente envia `pagina=abc` (não numérico)
+- **THEN** sistema retorna HTTP 400 com `{"error": "pagina deve ser um inteiro positivo"}`

--- a/openspec/specs/api-temas/spec.md
+++ b/openspec/specs/api-temas/spec.md
@@ -1,0 +1,36 @@
+# Spec: api-temas
+
+## Objetivo
+
+Definir o endpoint `GET /api/temas` do backend Flask, retornando todas as categorias com o total de proposições vinculadas.
+
+## Contexto
+
+Consumido pelo frontend para popular filtros de subtema e exibir contagens. Implementado em `src/backend/controllers/proposicoes_controller.py`; delegado a `listar_categorias_com_total` no repositório.
+
+## Escopo
+
+- Retorna array JSON de categorias com campo `total` adicional
+- Ordenado por `total` DESC
+- Inclui categorias com 0 proposições
+
+## Requisitos
+
+### Requirement: Listagem de temas (categorias) com totais
+O sistema SHALL expor `GET /api/temas` retornando todas as categorias ativas com o total de proposições vinculadas a cada uma. A resposta SHALL ser um array JSON.
+
+#### Scenario: Lista de temas com contagens
+- **WHEN** cliente faz `GET /api/temas`
+- **THEN** sistema retorna HTTP 200 com array de objetos, cada um contendo: `id`, `nome`, `descricao`, `cor`, `icone`, `ativa`, `total` (número de proposições vinculadas)
+
+#### Scenario: Ordenação por total DESC
+- **WHEN** sistema retorna os temas
+- **THEN** lista SHALL ser ordenada por `total` decrescente (temas com mais proposições primeiro)
+
+#### Scenario: Tema sem proposições
+- **WHEN** uma categoria existe mas não tem proposições vinculadas
+- **THEN** esse tema aparece na lista com `total: 0`
+
+#### Scenario: Banco sem categorias
+- **WHEN** tabela categorias está vazia
+- **THEN** sistema retorna HTTP 200 com array vazio `[]`

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -22,9 +22,11 @@ app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev-secret")
 
 from src.backend.database import db
 from src.backend import models  # noqa: F401
+from src.backend.controllers.proposicoes_controller import proposicoes_bp
 
 db.init_app(app)
 migrate = Migrate(app, db)
+app.register_blueprint(proposicoes_bp)
 
 # Seed de categorias e scheduler (pula em modo de testes)
 if os.getenv("FLASK_ENV") != "testing":

--- a/src/backend/controllers/proposicoes_controller.py
+++ b/src/backend/controllers/proposicoes_controller.py
@@ -1,0 +1,129 @@
+import logging
+
+from flask import Blueprint, jsonify, request
+
+from src.backend.repository import camara_repository as repo
+
+logger = logging.getLogger(__name__)
+
+proposicoes_bp = Blueprint("proposicoes", __name__)
+
+
+def _serializar_proposicao(prop):
+    d = prop.to_dict()
+    d["status"] = prop.descricao_situacao
+    cats = d.get("categorias", [])
+    d["subtema"] = cats[0]["nome"] if cats else None
+    d["nome_autor"] = None
+    return d
+
+
+def _serializar_tramitacao(t):
+    d = t.to_dict()
+    d["data"] = d["data_hora"]
+    d["descricao"] = d["descricao_tramitacao"]
+    d["orgao"] = d["sigla_orgao"]
+    return d
+
+
+@proposicoes_bp.route("/api/proposicoes")
+def listar_proposicoes():
+    try:
+        pagina = int(request.args.get("pagina", 1))
+        por_pagina = int(request.args.get("por_pagina", 10))
+        if pagina < 1 or por_pagina < 1:
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify({"error": "pagina e por_pagina devem ser inteiros positivos"}), 400
+
+    por_pagina = min(por_pagina, 50)
+
+    filtros = {
+        "q": request.args.get("q") or None,
+        "parlamentar": request.args.get("parlamentar") or None,
+        "partido": request.args.get("partido") or None,
+        "data_inicio": request.args.get("data_inicio") or None,
+        "data_fim": request.args.get("data_fim") or None,
+        "subtema": request.args.get("subtema") or None,
+    }
+
+    try:
+        items, total = repo.listar_proposicoes_paginado(filtros, pagina, por_pagina)
+    except Exception as exc:
+        logger.exception("Erro ao listar proposições")
+        return jsonify({"error": "Erro ao buscar proposições"}), 500
+
+    total_paginas = (total + por_pagina - 1) // por_pagina if por_pagina else 1
+
+    return jsonify({
+        "items": [_serializar_proposicao(p) for p in items],
+        "total": total,
+        "pagina": pagina,
+        "total_paginas": total_paginas,
+    })
+
+
+@proposicoes_bp.route("/api/proposicoes/<int:proposicao_id>")
+def detalhe_proposicao(proposicao_id):
+    try:
+        prop = repo.get_proposicao_detalhe(proposicao_id)
+    except Exception as exc:
+        logger.exception("Erro ao buscar proposição %s", proposicao_id)
+        return jsonify({"error": "Erro ao buscar proposição"}), 500
+
+    if prop is None:
+        return jsonify({"error": "Proposição não encontrada"}), 404
+
+    tramitacoes = sorted(prop.tramitacoes.all(), key=lambda t: t.data_hora)
+
+    return jsonify({
+        "proposicao": _serializar_proposicao(prop),
+        "tramitacoes": [_serializar_tramitacao(t) for t in tramitacoes],
+    })
+
+
+@proposicoes_bp.route("/api/estatisticas")
+def estatisticas():
+    try:
+        dados = repo.get_estatisticas_dashboard()
+    except Exception as exc:
+        logger.exception("Erro ao calcular estatísticas")
+        return jsonify({"error": "Erro ao calcular estatísticas"}), 500
+
+    return jsonify({
+        "resumo": {
+            "total": dados["total"],
+            "ativas": dados["ativas"],
+            "subtemas": dados["subtemas"],
+            "alertas": 0,
+        },
+        "ultima_atualizacao": dados["ultima_atualizacao"],
+        "por_subtema": dados["por_subtema"],
+        "por_status": dados["por_status"],
+        "temporal": dados["temporal"],
+    })
+
+
+@proposicoes_bp.route("/api/temas")
+def temas():
+    try:
+        categorias = repo.listar_categorias_com_total()
+    except Exception as exc:
+        logger.exception("Erro ao listar temas")
+        return jsonify({"error": "Erro ao listar temas"}), 500
+
+    return jsonify(categorias)
+
+
+@proposicoes_bp.app_errorhandler(404)
+def not_found(e):
+    if request.path.startswith("/api/"):
+        return jsonify({"error": "Recurso não encontrado"}), 404
+    return e
+
+
+@proposicoes_bp.app_errorhandler(500)
+def internal_error(e):
+    if request.path.startswith("/api/"):
+        return jsonify({"error": "Erro interno do servidor"}), 500
+    return e

--- a/src/backend/repository/camara_repository.py
+++ b/src/backend/repository/camara_repository.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from src.backend.database import db
@@ -216,3 +217,165 @@ def get_ultimas_execucoes(limite: int = 10) -> list[SyncExecution]:
         .limit(limite)
         .all()
     )
+
+
+# ── Leitura para API pública ──────────────────────────────────────────────────
+
+_MESES_PT = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"]
+
+
+def listar_proposicoes_paginado(
+    filtros: dict,
+    pagina: int = 1,
+    por_pagina: int = 10,
+) -> tuple[list[Proposicao], int]:
+    """Lista proposições com filtros opcionais e paginação.
+
+    filtros aceita: q, parlamentar (ignorado — campo não existe no schema),
+    partido, data_inicio, data_fim, subtema.
+    Retorna (items, total).
+    """
+    query = db.session.query(Proposicao)
+
+    q = filtros.get("q")
+    if q:
+        query = query.filter(Proposicao.ementa.ilike(f"%{q}%"))
+
+    partido = filtros.get("partido")
+    if partido:
+        query = query.filter(Proposicao.sigla_partido.ilike(f"%{partido}%"))
+
+    data_inicio = filtros.get("data_inicio")
+    if data_inicio:
+        query = query.filter(Proposicao.data_apresentacao >= data_inicio)
+
+    data_fim = filtros.get("data_fim")
+    if data_fim:
+        query = query.filter(Proposicao.data_apresentacao <= data_fim)
+
+    subtema = filtros.get("subtema")
+    if subtema:
+        query = query.filter(
+            Proposicao.categorias.any(Categoria.nome.ilike(f"%{subtema}%"))
+        )
+
+    total = query.count()
+    offset = (pagina - 1) * por_pagina
+    items = (
+        query
+        .order_by(Proposicao.data_apresentacao.desc())
+        .offset(offset)
+        .limit(por_pagina)
+        .all()
+    )
+    return items, total
+
+
+def get_proposicao_detalhe(proposicao_id: int) -> Proposicao | None:
+    """Retorna proposição por PK ou None. Tramitações e categorias via relacionamento."""
+    return db.session.get(Proposicao, proposicao_id)
+
+
+def get_estatisticas_dashboard() -> dict:
+    """Retorna métricas agregadas para o dashboard."""
+    total = db.session.query(func.count(Proposicao.id)).scalar() or 0
+
+    ativas = (
+        db.session.query(func.count(Proposicao.id))
+        .filter(Proposicao.descricao_situacao == "Em tramitação")
+        .scalar() or 0
+    )
+
+    subtemas = (
+        db.session.query(
+            func.count(func.distinct(proposicao_categoria.c.categoria_id))
+        ).scalar() or 0
+    )
+
+    por_subtema_rows = (
+        db.session.query(
+            Categoria.nome,
+            func.count(proposicao_categoria.c.proposicao_id).label("total"),
+        )
+        .outerjoin(proposicao_categoria, proposicao_categoria.c.categoria_id == Categoria.id)
+        .group_by(Categoria.id, Categoria.nome)
+        .having(func.count(proposicao_categoria.c.proposicao_id) > 0)
+        .order_by(func.count(proposicao_categoria.c.proposicao_id).desc())
+        .all()
+    )
+    por_subtema = {
+        "labels": [r.nome for r in por_subtema_rows],
+        "values": [r.total for r in por_subtema_rows],
+    }
+
+    por_status_rows = (
+        db.session.query(Proposicao.descricao_situacao, func.count(Proposicao.id).label("total"))
+        .group_by(Proposicao.descricao_situacao)
+        .order_by(func.count(Proposicao.id).desc())
+        .all()
+    )
+    por_status = {
+        "labels": [r.descricao_situacao for r in por_status_rows],
+        "values": [r.total for r in por_status_rows],
+    }
+
+    _ano = func.extract("year", Proposicao.data_apresentacao)
+    _mes = func.extract("month", Proposicao.data_apresentacao)
+    temporal_rows = (
+        db.session.query(
+            _ano.label("ano"),
+            _mes.label("mes"),
+            func.count(Proposicao.id).label("contagem"),
+        )
+        .group_by(_ano, _mes)
+        .order_by(_ano, _mes)
+        .all()
+    )
+    temporal = {
+        "labels": [
+            f"{_MESES_PT[int(r.mes) - 1]}/{int(r.ano)}" for r in temporal_rows
+        ],
+        "values": [r.contagem for r in temporal_rows],
+    }
+
+    ultimo_sync = (
+        db.session.query(SyncExecution.finalizado_em)
+        .filter(
+            SyncExecution.status.in_([
+                SyncExecution.STATUS_CONCLUIDO,
+                SyncExecution.STATUS_CONCLUIDO_PARC,
+            ])
+        )
+        .order_by(SyncExecution.finalizado_em.desc())
+        .first()
+    )
+    ultima_atualizacao = (
+        ultimo_sync.finalizado_em.isoformat()
+        if ultimo_sync and ultimo_sync.finalizado_em
+        else None
+    )
+
+    return {
+        "total": total,
+        "ativas": ativas,
+        "subtemas": subtemas,
+        "por_subtema": por_subtema,
+        "por_status": por_status,
+        "temporal": temporal,
+        "ultima_atualizacao": ultima_atualizacao,
+    }
+
+
+def listar_categorias_com_total() -> list[dict]:
+    """Lista todas as categorias com total de proposições vinculadas, ordenado por total DESC."""
+    rows = (
+        db.session.query(
+            Categoria,
+            func.count(proposicao_categoria.c.proposicao_id).label("total"),
+        )
+        .outerjoin(proposicao_categoria, proposicao_categoria.c.categoria_id == Categoria.id)
+        .group_by(Categoria.id)
+        .order_by(func.count(proposicao_categoria.c.proposicao_id).desc())
+        .all()
+    )
+    return [{**cat.to_dict(), "total": total} for cat, total in rows]


### PR DESCRIPTION
## Descrição
 
### Contexto
 
O frontend Vue 3 do LegisKids já estava implementado consumindo 4 endpoints REST, mas esses endpoints simplesmente não existiam no Flask — qualquer requisição retornava 404. Isso bloqueava a Release 1, com entrega prevista para quarta-feira.
 
### O que foi feito
 
**Análise prévia** — antes de qualquer código, foi mapeado: os 11 métodos já existentes em `camara_repository.py` (todos voltados a ETL, nenhum de leitura), o schema real das tabelas `proposicoes`, `categorias`, `proposicao_categoria` e `sync_executions`, e todas as chamadas HTTP feitas pelo frontend (params enviados e campos lidos na resposta).
 
Esse mapeamento revelou gaps entre o que o frontend espera e o que o banco tem (ex: frontend lê `status`, banco tem `descricao_situacao`; frontend lê `autor`, campo não existe no schema). Esses gaps foram resolvidos via aliases e fallbacks no controller, sem alterar o schema.
 
**Planejamento** — mudança documentada via OpenSpec (`flask-api-routes-proposicoes`): proposta, decisões técnicas (blueprint separado, aliases no controller e não nos models, queries centralizadas no repositório, lazy loading explícito para tramitações), specs por capability com cenários WHEN/THEN, e 16 tasks divididas em repositório → controller → app.py → verificação.
 
**Implementação**
 
- `camara_repository.py`: 4 métodos novos de leitura — `listar_proposicoes_paginado`, `get_proposicao_detalhe`, `get_estatisticas_dashboard`, `listar_categorias_com_total`
- `controllers/proposicoes_controller.py` (novo): blueprint com as 4 rotas, serialização com aliases (`status`, `subtema`, `nome_autor`, e equivalentes em tramitações), validação de params, cap de 50 itens/página, error handlers JSON para 404/500
- `app.py`: registro do blueprint (2 linhas)
**Bugfix durante a implementação**: PostgreSQL rejeita alias no `GROUP BY` — a query temporal de estatísticas foi corrigida para usar as expressões `func.extract(...)` diretamente no `group_by()` em vez do alias da coluna.
 
### Verificação
 
Testado manualmente com o servidor Flask rodando ao vivo (sem mocks):
 
| Rota | Resultado |
|---|---|
| `GET /api/temas` | 200, 8 categorias com campo `total` |
| `GET /api/proposicoes` | 200, paginação e filtros corretos |
| `GET /api/proposicoes/2635088` | 200, proposição + tramitações |
| `GET /api/estatisticas` | 200, todas as chaves esperadas pelo dashboard |
| `GET /api/proposicoes/99999999` | 404, JSON `{"error": "Proposição não encontrada"}` |
 
Front local conectado ao backend local: dashboard exibindo dados reais do Neon em vez de "Nenhum dado disponível".
 
### Arquivos alterados
 
| Arquivo | Operação |
|---|---|
| `src/backend/repository/camara_repository.py` | Editado |
| `src/backend/controllers/proposicoes_controller.py` | Criado |
| `src/backend/app.py` | Editado |
 
### Como testar
 
```bash
.venv\Scripts\python.exe -m flask --app src/backend/app.py run
```
E navegar pelo frontend local apontando para `http://localhost:5000`, ou testar as rotas diretamente via curl/Postman/navegador.
 
### Checklist
 
- [x] Rotas implementadas e testadas manualmente
- [x] Nenhuma alteração em `camara_service.py`, `camara_scheduler.py`
- [x] Specs documentados e arquivados via OpenSpec
- [ ] Deploy em produção (próxima issue)
- [ ] Testes automatizados (fora do escopo desta entrega)