### PR TITLE
Docs/210 guia execucao local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
 FLASK_APP=src/backend/app.py
-FLASK_ENV=development
+# Evita iniciar o scheduler de sincronização ao executar o backend localmente
+FLASK_ENV=testing
 SECRET_KEY=troque-por-uma-chave-secreta-longa-e-aleatoria
 
-# Conexão com o banco de dados PostgreSQL
-# Desenvolvimento local:
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
-# Neon (produção) — incluir ?sslmode=require obrigatoriamente:
-# DATABASE_URL=postgresql://<user>:<senha>@<host>.neon.tech/<db>?sslmode=require
+# Conexão com o banco Neon
+# Solicite a connection string ao responsável pelo banco ou copie-a pelo
+# botão "Connect" no painel do Neon. Nunca commite a credencial real.
+# Formato:
+# postgresql://<user>:<senha>@<host>.neon.tech/<db>?sslmode=require&channel_binding=require
+DATABASE_URL=
 
 # Chave da API do Google Gemini para classificação automática
 GOOGLE_API_KEY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,34 +207,41 @@ Closes #numero
 
 ## Ambiente Local
 
-### Instalar dependências
-
-```bash
-pip install -r requirements.txt
-```
-
----
-
-### Executar documentação
-
-```bash
-mkdocs serve
-```
-
----
+O passo a passo completo de instalação está no
+[README](README.md#como-executar-localmente).
 
 ### Executar API
 
 ```bash
-uvicorn src.auth_api.main:app --reload
+python -m flask --app src/backend/app.py run --debug
 ```
 
----
+### Executar documentação
+
+```bash
+python -m pip install -r requirements-docs.txt
+python -m mkdocs serve
+```
+
+Antes de enviar mudanças na documentação, valide o build:
+
+```bash
+python -m mkdocs build --strict
+```
+
+### Executar frontend
+
+```bash
+cd src/frontend
+npm install
+npm run dev
+```
 
 ### Executar testes
 
 ```bash
-pytest
+python -m pip install pytest
+python -m pytest tests/
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,10 @@ Closes #numero
 O passo a passo completo de instalação está no
 [README](README.md#como-executar-localmente).
 
+Use a `DATABASE_URL` do Neon fornecida pela equipe. Não execute migrations ou
+o seed no banco compartilhado sem autorização do responsável. Mantenha
+`FLASK_ENV=testing` no ambiente local para não iniciar o scheduler diário.
+
 ### Executar API
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ scripts/             -> scripts auxiliares
 * Git
 * Python 3.10+
 * Node.js 18+ e npm 9+
-* Docker com Docker Compose
+* Acesso à `DATABASE_URL` do projeto no Neon
 
 ### 1. Clonar o repositório
 
@@ -150,28 +150,23 @@ python -m pip install -r requirements.txt
 cp .env.example .env
 ```
 
-No Windows, use `copy .env.example .env`. O arquivo fornecido já aponta para o
-PostgreSQL local do `docker-compose.yml`. Preencha `GOOGLE_API_KEY` apenas se
-for executar a classificação automática.
+No Windows, use `copy .env.example .env`.
 
-### 3. Iniciar o banco de dados
+Abra o `.env` e substitua a `DATABASE_URL` vazia pela connection string
+fornecida pelo responsável pelo banco:
 
-```bash
-docker compose up -d
-docker compose ps
+```env
+DATABASE_URL=postgresql://<usuario>:<senha>@<host>.neon.tech/<banco>?sslmode=require&channel_binding=require
 ```
 
-Aguarde o serviço `db` ficar saudável antes de continuar. O volume
-`legiskids_db_data` mantém os dados entre reinicializações.
+Copie a connection string completa pelo botão **Connect** no painel do Neon ou
+solicite-a ao responsável pelo banco. Ela contém credenciais e deve permanecer
+somente no `.env`; nunca a publique em commits, issues ou mensagens abertas.
+Preencha `GOOGLE_API_KEY` apenas se for executar a classificação automática.
+O `FLASK_ENV=testing` do exemplo impede que o scheduler diário seja iniciado
+por cada ambiente local conectado ao banco compartilhado.
 
-### 4. Aplicar as migrations e popular o banco
-
-```bash
-python -m flask --app src/backend/app.py db upgrade
-python scripts/seed.py
-```
-
-### 5. Iniciar o backend
+### 3. Iniciar o backend
 
 ```bash
 python -m flask --app src/backend/app.py run --debug
@@ -180,7 +175,11 @@ python -m flask --app src/backend/app.py run --debug
 A API estará disponível em `http://127.0.0.1:5000`. Para verificar a conexão
 com o banco, acesse `http://127.0.0.1:5000/health`.
 
-### 6. Iniciar o frontend
+> Não execute migrations ou o seed no banco compartilhado sem autorização do
+> responsável pelo banco. Alterações de schema devem ser coordenadas pela
+> equipe.
+
+### 4. Iniciar o frontend
 
 Em outro terminal, a partir da raiz do repositório:
 
@@ -199,21 +198,6 @@ Para gerar o build de produção:
 ```bash
 npm run build
 ```
-
-### 7. Encerrar o banco
-
-```bash
-docker compose down
-```
-
-Use `docker compose down -v` somente quando também quiser apagar os dados
-persistidos localmente.
-
-### Usar o Neon em vez do banco local
-
-Substitua a `DATABASE_URL` do arquivo `.env` pela connection string fornecida
-no painel do [Neon](https://neon.tech), incluindo `?sslmode=require`. Depois,
-execute normalmente as migrations e o seed. Nunca publique essa credencial.
 
 ## Como Executar a Documentação
 

--- a/README.md
+++ b/README.md
@@ -109,54 +109,14 @@ scripts/             -> scripts auxiliares
 
 ---
 
-## Como Executar o Frontend
+## Como Executar Localmente
 
 ### Pré-requisitos
 
-* Node.js 18+
-* npm 9+
-
-### 1. Instalar dependências
-
-```bash
-cd src/frontend
-npm install
-```
-
-### 2. Configurar variáveis de ambiente
-
-```bash
-cp .env.example .env
-# Edite .env se o backend estiver em outra porta/host
-```
-
-### 3. Iniciar o servidor de desenvolvimento
-
-```bash
-npm run dev
-# Disponível em http://localhost:5173
-```
-
-### 4. Build de produção
-
-```bash
-npm run build
-# Saída em src/frontend/dist/
-```
-
----
-
-## Como Executar a Documentação
-
-### Pré-requisitos
-
-Certifique-se de possuir:
-
-* Python 3.10+
-* pip
 * Git
-
----
+* Python 3.10+
+* Node.js 18+ e npm 9+
+* Docker com Docker Compose
 
 ### 1. Clonar o repositório
 
@@ -165,170 +125,120 @@ git clone https://github.com/unb-mds/2026-1-LegisKids.git
 cd 2026-1-LegisKids
 ```
 
----
+### 2. Preparar o backend
 
-### 2. Criar ambiente virtual
+Crie e ative um ambiente virtual:
 
-#### Linux/Mac
-
-```bash
-python -m venv venv
-source venv/bin/activate
-```
-
-#### Windows
+#### Linux/macOS
 
 ```bash
-python -m venv venv
-venv\Scripts\activate
+python3 -m venv .venv
+source .venv/bin/activate
 ```
 
----
+#### Windows (PowerShell)
 
-### 3. Instalar dependências
+```powershell
+py -m venv .venv
+.venv\Scripts\Activate.ps1
+```
+
+Instale as dependências e crie o arquivo de configuração local:
 
 ```bash
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
+cp .env.example .env
 ```
 
-### 5. Configurar o banco de dados
+No Windows, use `copy .env.example .env`. O arquivo fornecido já aponta para o
+PostgreSQL local do `docker-compose.yml`. Preencha `GOOGLE_API_KEY` apenas se
+for executar a classificação automática.
 
-O projeto suporta dois modos de banco de dados:
-
-#### Banco local com Docker (desenvolvimento diário)
-
-Suba o PostgreSQL usando o `docker-compose.yml` do projeto:
+### 3. Iniciar o banco de dados
 
 ```bash
 docker compose up -d
-```
-
-Aguarde o container ficar saudável (alguns segundos) antes de continuar. Para verificar:
-
-```bash
 docker compose ps
 ```
 
-Para parar:
+Aguarde o serviço `db` ficar saudável antes de continuar. O volume
+`legiskids_db_data` mantém os dados entre reinicializações.
 
-```bash
-docker compose down
-```
-
-> O volume `legiskids_db_data` persiste os dados entre reinicializações. Para apagar tudo e começar do zero: `docker compose down -v`
-
-#### Banco Neon (homologação e testes remotos)
-
-Obtenha a connection string no painel do [Neon](https://neon.tech) e use-a no `.env` local.
-
-### 6. Configurar variáveis de ambiente
-
-Copie o arquivo de exemplo e edite com suas credenciais:
-
-```bash
-cp .env.example .env
-```
-
-Exemplo para banco local Docker:
-
-```env
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
-FLASK_APP=src/backend/app.py
-FLASK_ENV=development
-SECRET_KEY=troque-por-uma-chave-secreta-longa-e-aleatoria
-```
-
-Exemplo para banco Neon:
-
-```env
-DATABASE_URL=postgresql://usuario:senha@host.neon.tech/legiskids?sslmode=require
-FLASK_APP=src/backend/app.py
-FLASK_ENV=development
-SECRET_KEY=troque-por-uma-chave-secreta-longa-e-aleatoria
-```
-
-> A connection string real do Neon deve ser obtida no painel e **nunca commitada**.
-
-### 7. Executar as migrations e popular o banco
-
-> **Pré-requisito:** o banco configurado na `DATABASE_URL` do seu `.env` precisa estar acessível antes de executar os comandos abaixo.
-> - Se usar banco local Docker: execute `docker compose up -d` primeiro.
-> - Se usar Neon: certifique-se de que a `DATABASE_URL` no `.env` aponta para o Neon com `?sslmode=require`.
-
-Aplique o schema:
-
-```bash
-python -m flask --app src/backend/app.py db upgrade
-```
-
-Popule o banco com dados iniciais:
-
-```bash
-python scripts/seed.py
-```
-
-> **Status de validação:**
-> - **Banco local Docker** — testado e validado: migrations aplicadas e seed executado com sucesso (17 partidos inseridos).
-> - **Banco Neon** — requer troca temporária do `DATABASE_URL` conforme instruções abaixo.
-
-#### Testando no banco Neon
-
-Para aplicar o schema e popular o banco remoto no Neon, troque temporariamente o `DATABASE_URL` no seu `.env` pela connection string do Neon (obtida no painel do [Neon](https://neon.tech)):
-
-```env
-# Temporário — para testar no Neon
-DATABASE_URL=postgresql://<usuario>:<senha>@<host>.neon.tech/<banco>?sslmode=require&channel_binding=require
-```
-
-### 7. Documentação do banco de dados
-
-A documentação completa do schema está disponível em [`docs/db/schema.md`](docs/db/schema.md), incluindo:
-- Diagrama Entidade-Relacionamento (ERD)
-- Descrição de cada tabela, colunas, tipos e constraints
-- Relacionamentos e decisões de design
-
-O código-fonte do ERD (editável no [dbdiagram.io](https://dbdiagram.io)) está em [`docs/db/erd.dbml`](docs/db/erd.dbml).
-
----
-
-### 8. Executar as migrations (se houver)
-Execute as migrations e o seed:
+### 4. Aplicar as migrations e popular o banco
 
 ```bash
 python -m flask --app src/backend/app.py db upgrade
 python scripts/seed.py
 ```
 
-### 9. Iniciar o servidor
-
-```text
-http://127.0.0.1:8000
-```
-
----
-
-## Subindo o banco com Docker
-
-Pré-requisito: [Docker Desktop](https://www.docker.com/products/docker-desktop/) instalado.
+### 5. Iniciar o backend
 
 ```bash
-# 1. Copie o arquivo de variáveis de ambiente
+python -m flask --app src/backend/app.py run --debug
+```
+
+A API estará disponível em `http://127.0.0.1:5000`. Para verificar a conexão
+com o banco, acesse `http://127.0.0.1:5000/health`.
+
+### 6. Iniciar o frontend
+
+Em outro terminal, a partir da raiz do repositório:
+
+```bash
+cd src/frontend
+npm install
 cp .env.example .env
+npm run dev
+```
 
-# 2. Suba o banco
-docker compose up -d
+No Windows, use `copy .env.example .env`. A aplicação estará disponível em
+`http://localhost:5173`.
 
-# 3. Aplique as migrations
-flask db upgrade
+Para gerar o build de produção:
 
-# 4. Popule com dados iniciais (opcional)
-python scripts/seed.py
+```bash
+npm run build
+```
 
-# 5. Pare o banco quando terminar
+### 7. Encerrar o banco
+
+```bash
 docker compose down
 ```
 
-> As credenciais são lidas do `.env`. Nenhuma senha está hardcoded no `docker-compose.yml`.
+Use `docker compose down -v` somente quando também quiser apagar os dados
+persistidos localmente.
+
+### Usar o Neon em vez do banco local
+
+Substitua a `DATABASE_URL` do arquivo `.env` pela connection string fornecida
+no painel do [Neon](https://neon.tech), incluindo `?sslmode=require`. Depois,
+execute normalmente as migrations e o seed. Nunca publique essa credencial.
+
+## Como Executar a Documentação
+
+Com o ambiente virtual ativo, instale as dependências específicas:
+
+```bash
+python -m pip install -r requirements-docs.txt
+python -m mkdocs serve
+```
+
+A documentação estará disponível em `http://127.0.0.1:8000`.
+
+Para validar o site antes de enviar alterações:
+
+```bash
+python -m mkdocs build --strict
+```
+
+## Documentação do Banco de Dados
+
+A documentação completa do schema está disponível em
+[`docs/db/schema.md`](docs/db/schema.md), incluindo o diagrama
+Entidade-Relacionamento, as tabelas, constraints e decisões de design.
+O código-fonte editável do ERD está em
+[`docs/db/erd.dbml`](docs/db/erd.dbml).
 
 ---
 

--- a/docs/estudos/banco_de_dados/configuracao_database_url.md
+++ b/docs/estudos/banco_de_dados/configuracao_database_url.md
@@ -1,270 +1,110 @@
-# Configuração de Banco de Dados via DATABASE_URL — LegisKids
+# Configuração da `DATABASE_URL`
 
-> Este documento cobre a issue de configuração unificada do banco de dados:
-> substituição das 5 variáveis separadas por uma única `DATABASE_URL`, suporte a
-> banco local Docker e banco remoto Neon, e criação do script de seed de dados iniciais.
+O LegisKids utiliza o PostgreSQL gerenciado no Neon. O backend Flask lê a
+conexão pela variável de ambiente `DATABASE_URL`.
 
----
+## Pré-requisitos
 
-## O que foi feito
+- Python 3.10 ou superior
+- Acesso à connection string do projeto no Neon
+- Dependências de `requirements.txt` instaladas em um ambiente virtual
 
-### Mudança principal: de 5 variáveis para `DATABASE_URL`
+## Configuração
 
-O `app.py` costumava montar a URI do banco manualmente a partir de cinco variáveis separadas:
-
-```env
-# Formato antigo (não usar mais)
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=legiskids
-DB_USER=postgres
-DB_PASSWORD=sua_senha
-```
-
-Agora o sistema usa uma única variável `DATABASE_URL` — o padrão adotado por praticamente todo ecossistema Python/PostgreSQL:
-
-```env
-# Formato atual
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
-```
-
-Essa mudança permite trocar de banco (local → Neon → qualquer outro) alterando apenas um valor no `.env`, sem mexer em código.
-
-### Arquivos criados ou alterados
-
-| Arquivo | O que mudou |
-|---|---|
-| `src/backend/app.py` | Removida montagem manual de URI; lê `DATABASE_URL` via `os.getenv()`; levanta `RuntimeError` se não definida |
-| `.env.example` | Atualizado com exemplos de `DATABASE_URL` para banco local Docker e banco Neon |
-| `.env` | Atualizado para o novo formato (arquivo local, não vai pro git) |
-| `docker-compose.yml` | Criado — sobe PostgreSQL 16 localmente via Docker sem instalar nada no sistema |
-| `scripts/seed.py` | Criado — popula o banco com dados iniciais (partidos); idempotente |
-| `README.md` | Seção "Configurar o banco de dados" atualizada com instruções para os dois ambientes |
-
----
-
-## Os dois ambientes de banco
-
-### Banco local com Docker (desenvolvimento diário)
-
-Usado por padrão para desenvolvimento. O banco roda em container e não exige PostgreSQL instalado no sistema.
-
-```env
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
-```
-
-**Validado:** migrations aplicadas e seed executado com sucesso (17 partidos inseridos).
-
-### Banco Neon (homologação e produção)
-
-Banco PostgreSQL gerenciado na nuvem, acessado via connection string com SSL obrigatório.
-
-```env
-DATABASE_URL=postgresql://<usuario>:<senha>@<host>.neon.tech/<banco>?sslmode=require&channel_binding=require
-```
-
-**Validado:** `flask db upgrade` e `python scripts/seed.py` executados com sucesso no banco remoto — tabelas criadas e 17 partidos inseridos no Neon.
-
-> A connection string real do Neon **nunca deve ser commitada**. Obtenha-a no painel do
-> [Neon](https://neon.tech) ou peça a um integrante do time via canal seguro.
-
----
-
-## Passo a passo para novos integrantes
-
-### 1. Clonar o repositório e criar o venv
-
-```bash
-git clone https://github.com/unb-mds/2026-1-LegisKids.git
-cd 2026-1-LegisKids
-
-# Linux/macOS
-python3 -m venv .venv
-source .venv/bin/activate
-
-# Windows
-python -m venv .venv
-.venv\Scripts\activate
-```
-
-### 2. Instalar dependências
-
-```bash
-pip install -r requirements.txt
-```
-
-### 3. Configurar o `.env`
+Na raiz do repositório, crie seu arquivo local:
 
 ```bash
 cp .env.example .env
 ```
 
-O `.env` padrão já aponta para o banco Docker local. Não precisa alterar nada para começar:
+No Windows, use:
+
+```powershell
+copy .env.example .env
+```
+
+Solicite a connection string ao responsável pelo banco ou copie-a pelo botão
+**Connect** no painel do Neon. Adicione o valor completo ao `.env`:
 
 ```env
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
-FLASK_APP=src/backend/app.py
-FLASK_ENV=development
-SECRET_KEY=troque-por-uma-chave-secreta-longa-e-aleatoria
-```
-
-### 4. Subir o banco local com Docker
-
-```bash
-docker compose up -d
-```
-
-Aguarde o container ficar saudável (status `healthy`):
-
-```bash
-docker compose ps
-```
-
-> O volume `legiskids_db_data` persiste os dados entre reinicializações.
-> Para apagar tudo e começar do zero: `docker compose down -v`
-
-### 5. Aplicar o schema (migrations)
-
-```bash
-python -m flask --app src/backend/app.py db upgrade
-```
-
-Saída esperada:
-
-```
-INFO  [alembic.runtime.migration] Running upgrade  -> 7deb4eaf030e, initial schema
-```
-
-Se o banco já estiver atualizado, o comando não faz nada (seguro rodar sempre).
-
-### 6. Popular o banco com dados iniciais
-
-```bash
-python scripts/seed.py
-```
-
-Saída esperada:
-
-```
-═══════════════════════════════════════════════════════
-  LegisKids — Seed de dados iniciais
-  Banco: localhost:5432/legiskids
-═══════════════════════════════════════════════════════
-
-── Partidos ─────────────────────────────────────────────
-  17 inserido(s) | 0 atualizado(s) | 0 sem alteração
-
-═══════════════════════════════════════════════════════
-  Seed concluído com sucesso.
-═══════════════════════════════════════════════════════
-```
-
-O seed é **idempotente**: pode ser rodado mais de uma vez sem criar duplicatas.
-
-### 7. Verificar que o Flask sobe corretamente
-
-```bash
-python -m flask --app src/backend/app.py run
-```
-
-Acesse **http://localhost:5000/health**. Resposta esperada:
-
-```json
-{ "status": "ok", "database": "conectado" }
-```
-
----
-
-## Como testar no banco Neon
-
-Quando precisar validar migrations ou dados no banco remoto (Neon), siga os passos abaixo.
-Isso é necessário uma vez por integrante ou sempre que houver nova migration.
-
-### 1. Trocar o `DATABASE_URL` no `.env` para o Neon
-
-Abra o `.env` e substitua a linha do `DATABASE_URL`:
-
-```env
-# Temporário — aponta para o Neon
 DATABASE_URL=postgresql://<usuario>:<senha>@<host>.neon.tech/<banco>?sslmode=require&channel_binding=require
 ```
 
-> Obtenha a connection string real com um colega do time ou no painel do Neon.
-> **Não commite** esse valor.
+O arquivo `.env` está ignorado pelo Git. A connection string contém
+credenciais e nunca deve ser publicada no repositório, em issues ou em canais
+abertos.
 
-### 2. Aplicar migrations no Neon
+## Execução local segura
+
+Mantenha esta configuração durante o desenvolvimento local:
+
+```env
+FLASK_ENV=testing
+```
+
+O backend usa esse valor para não iniciar o scheduler diário de sincronização
+em cada computador conectado ao banco compartilhado.
+
+Inicie a API:
+
+```bash
+python -m flask --app src/backend/app.py run --debug
+```
+
+Verifique a conexão em:
+
+```text
+http://127.0.0.1:5000/health
+```
+
+Resposta esperada:
+
+```json
+{
+  "status": "ok",
+  "database": "conectado"
+}
+```
+
+## Migrations e seed
+
+Não execute migrations, seed ou sincronizações manuais no banco compartilhado
+sem autorização do responsável. Esses comandos podem alterar schema e dados
+usados por toda a equipe.
+
+Quando uma alteração for autorizada:
 
 ```bash
 python -m flask --app src/backend/app.py db upgrade
-```
-
-### 3. Executar o seed no Neon
-
-```bash
 python scripts/seed.py
 ```
 
-A saída deve mostrar o host do Neon e os dados inseridos.
+Revise sempre se a `DATABASE_URL` aponta para o ambiente correto antes de
+executá-los.
 
-### 4. Restaurar o `.env` para banco local
+## Solução de problemas
 
-```bash
-# Abra o .env e volte para:
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/legiskids
+### `DATABASE_URL não configurada`
+
+Confira se o `.env` existe na raiz e se `DATABASE_URL` recebeu a connection
+string completa.
+
+### Erro de autenticação
+
+Copie novamente a connection string pelo painel do Neon. Não tente corrigir
+usuário, senha ou host manualmente.
+
+### Erro de conexão segura
+
+Use a connection string completa fornecida pelo Neon, incluindo os parâmetros
+de segurança:
+
+```text
+?sslmode=require&channel_binding=require
 ```
 
----
+### `/health` funciona, mas os endpoints não retornam dados
 
-## O script `scripts/seed.py`
-
-O seed popula o banco com dados fixos necessários para a aplicação funcionar — atualmente os 17 partidos registrados na API da Câmara.
-
-**Características:**
-- Idempotente: verifica existência pela PK antes de inserir (nunca duplica)
-- Atualiza campos se o registro existe mas os dados mudaram (sigla ou nome)
-- Nunca apaga registros existentes
-- Extensível: há comentários indicando onde adicionar novas tabelas
-
-Para adicionar dados de uma nova tabela ao seed, abra `scripts/seed.py` e siga o padrão das funções `seed_partidos()` já existentes.
-
----
-
-## Comandos do dia a dia
-
-| Situação | Comando |
-|---|---|
-| Subir o banco Docker | `docker compose up -d` |
-| Parar o banco Docker | `docker compose down` |
-| Aplicar migrations / atualizar banco | `python -m flask --app src/backend/app.py db upgrade` |
-| Popular banco com dados iniciais | `python scripts/seed.py` |
-| Subir o servidor Flask | `python -m flask --app src/backend/app.py run` |
-| Gerar nova migration após mudar model | `flask db migrate -m "descricao"` |
-| Reverter última migration | `flask db downgrade` |
-| Ver histórico de migrations | `flask db history` |
-
----
-
-## Problemas comuns
-
-**`RuntimeError: DATABASE_URL não configurada no ambiente.`**
-O arquivo `.env` não foi criado ou a variável está ausente. Execute `cp .env.example .env` e verifique o conteúdo.
-
-**`connection refused` na porta 5432**
-O container Docker não está rodando. Execute `docker compose up -d` e aguarde o status `healthy`.
-
-**`No module named 'flask_migrate'`**
-O venv não está ativado ou as dependências não foram instaladas.
-Execute `source .venv/bin/activate` e depois `pip install -r requirements.txt`.
-
-**`Error: No such command 'db'`**
-O Flask não encontrou o app. Verifique se `FLASK_APP=src/backend/app.py` está no `.env` e use
-`python -m flask --app src/backend/app.py db upgrade` em vez de só `flask db upgrade`.
-
-**`SSL connection required` ao conectar no Neon**
-A connection string do Neon precisa de `?sslmode=require`. Verifique o `DATABASE_URL` no `.env`.
-
-**Banco desatualizado após puxar mudanças do git**
-Execute `python -m flask --app src/backend/app.py db upgrade`. O Alembic aplica só as migrations novas.
-
-**Seed rodou mas não aparece nada no banco**
-Verifique se o `DATABASE_URL` no `.env` aponta para o banco correto (local ou Neon) antes de rodar.
+O healthcheck confirma a conexão, mas não garante que o schema e os dados
+estejam disponíveis. Informe o responsável pelo banco antes de aplicar
+migrations ou seed.

--- a/docs/estudos/banco_de_dados/guia_integrantes.md
+++ b/docs/estudos/banco_de_dados/guia_integrantes.md
@@ -1,433 +1,135 @@
-# Configuração do Ambiente e Banco de Dados — LegisKids
+# Guia de Banco de Dados para Integrantes
 
-> Este documento cobre três issues:
-> - [Issue #31](https://github.com/unb-mds/2026-1-LegisKids/issues/31) — Configuração do ambiente e conexão com PostgreSQL
-> - Issue de Modelagem — Criação das tabelas principais do banco de dados
-> - Issue de Migrations — Versionamento do schema com Flask-Migrate
+Este guia apresenta o fluxo seguro para acessar o banco compartilhado do
+LegisKids no Neon durante o desenvolvimento.
 
----
+## Visão geral
 
-## O que foi feito
+O backend utiliza:
 
-### Issue #31 — Ambiente e conexão com PostgreSQL
+- PostgreSQL hospedado no Neon;
+- SQLAlchemy para acesso aos dados;
+- Flask-Migrate e Alembic para versionamento do schema;
+- `DATABASE_URL` para configuração da conexão.
 
-| Arquivo | O que faz |
-|---|---|
-| `.env.example` | Documenta todas as variáveis de ambiente. Este arquivo **vai pro git**. |
-| `.env` | Suas credenciais locais reais. Este arquivo **nunca vai pro git**. |
-| `.gitignore` | Protege o `.env`, `venv/`, `site/` e outros artefatos. |
-| `src/backend/app.py` | Entrypoint do Flask com SQLAlchemy configurado via variáveis de ambiente. Inclui rota `/health` para checar o banco. |
-| `src/backend/database.py` | Instância isolada do `db` (SQLAlchemy). Separado do `app.py` para evitar importação circular. |
-| `src/backend/controllers/` | Pasta da camada de controllers (arquitetura em camadas). |
-| `src/backend/repository/` | Pasta da camada de repositório (arquitetura em camadas). |
-| `test_db.py` | Valida se a conexão com o PostgreSQL está funcionando. |
-| `requirements.txt` | Adicionados: `Flask`, `Flask-SQLAlchemy`, `psycopg2-binary`, `python-dotenv`, `Flask-Migrate`. |
+As credenciais ficam somente no arquivo local `.env`, que não deve ser
+versionado.
 
-### Issue de Modelagem — Tabelas do banco de dados
+## Preparar o ambiente
 
-| Arquivo | O que faz |
-|---|---|
-| `src/backend/models.py` | Modelos SQLAlchemy de todas as tabelas — use para interagir com o banco via Python. |
-| `src/backend/migrations/create_tables.sql` | SQL de referência das tabelas. Não usar para criar o banco — use `flask db upgrade`. |
-| `src/backend/migrations/test_tables.py` | Testa a criação, inserção e relacionamentos de todas as tabelas. |
-
-### Issue de Migrations — Flask-Migrate
-
-| Arquivo/Pasta | O que faz |
-|---|---|
-| `migrations/` | Pasta gerada pelo Flask-Migrate com todo o histórico de versões do banco. |
-| `migrations/versions/` | Arquivos de migration gerados automaticamente pelo Alembic. |
-| `migrations/env.py` | Configuração do Alembic para detectar os models do projeto. |
-
----
-
-## Por que Flask-Migrate?
-
-Sem versionamento de banco, cada integrante precisaria rodar o SQL manualmente e qualquer mudança no schema precisaria ser comunicada por fora. Com o Flask-Migrate:
-
-- O banco é **reproduzido do zero** com um único comando (`flask db upgrade`)
-- Mudanças no schema viram **arquivos commitados** — rastreáveis pelo git
-- É possível **reverter** alterações sem perder dados (`flask db downgrade`)
-- Novos integrantes não precisam entender o SQL — só rodar o comando
-
----
-
-## Por que o `database.py` existe?
-
-O `db` (instância do SQLAlchemy) foi separado do `app.py` em um arquivo próprio (`database.py`) para evitar **importação circular**:
-
-- `app.py` precisa importar `models.py` para o Flask-Migrate detectar as tabelas
-- `models.py` precisa importar `db` para definir os modelos
-- Se `db` ficasse no `app.py`, teríamos um ciclo: `app → models → app`
-
-Com o `database.py` quebramos esse ciclo:
-
-```
-app.py    →  database.py  (importa db)
-models.py →  database.py  (importa db)
-app.py    →  models.py    (importa os modelos)
-```
-
----
-
-## Arquitetura do backend
-
-```
-src/backend/
-├── app.py                  ← entrypoint Flask + configuração do banco
-├── database.py             ← instância do db (SQLAlchemy) — separado para evitar ciclo
-├── models.py               ← modelos SQLAlchemy (todas as tabelas)
-├── main.py                 ← script CLI de consumo da API da Câmara (pré-existente)
-├── migrations/
-│   ├── create_tables.sql   ← SQL de referência (documentação)
-│   └── test_tables.py      ← script de teste das tabelas
-├── controllers/            ← recebe as requisições HTTP
-│   └── __init__.py
-├── services/               ← regras de negócio
-│   └── camara_api.py
-└── repository/             ← acesso ao banco de dados
-    └── __init__.py
-
-migrations/                 ← gerado pelo Flask-Migrate (na raiz do projeto)
-├── env.py
-├── alembic.ini
-├── script.py.mako
-└── versions/
-    └── xxxx_initial_schema.py
-```
-
----
-
-## Tabelas criadas
-
-| Tabela | Finalidade |
-|---|---|
-| `partidos` | Partidos políticos associados às proposições |
-| `proposicoes` | Proposições legislativas coletadas da API da Câmara |
-| `tramitacoes` | Histórico de tramitação de cada proposição |
-| `usuarios` | Usuários autenticados via Google OAuth |
-| `favoritos` | Proposições salvas por usuários |
-| `historico_consultas` | Histórico de pesquisas dos usuários |
-| `requisicoes_api` | Monitoramento e auditoria das coletas da API |
-
-### Relacionamentos
-
-```
-partidos ──────────────── proposicoes          (1 para N)
-proposicoes ──────────── tramitacoes           (1 para N)
-proposicoes ──────────── favoritos             (1 para N)
-usuarios ─────────────── favoritos             (1 para N)
-usuarios ─────────────── historico_consultas   (1 para N)
-```
-
----
-
-## Pré-requisitos
-
-Antes de começar, você precisa ter instalado:
-
-- **Python 3.11+** — [python.org/downloads](https://python.org/downloads)
-- **PostgreSQL** — [postgresql.org/download](https://postgresql.org/download)
-- **Git** — [git-scm.com](https://git-scm.com)
-
----
-
-## Passo a passo para novos integrantes
-
-### 1. Clonar o repositório
+Clone o projeto e entre na pasta:
 
 ```bash
 git clone https://github.com/unb-mds/2026-1-LegisKids.git
 cd 2026-1-LegisKids
 ```
 
-### 2. Criar e ativar o ambiente virtual
+Crie e ative o ambiente virtual:
 
-> ⚠️ **Sempre que abrir o projeto, ative o venv antes de qualquer coisa.**
+=== "Linux/macOS"
 
-O ambiente virtual isola as dependências do projeto do Python do seu sistema — evita conflitos entre versões de bibliotecas.
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    ```
 
-**Linux/macOS:**
-```bash
-python3 -m venv venv
-source venv/bin/activate
-```
+=== "Windows (PowerShell)"
 
-**Windows:**
-```bash
-python -m venv venv
-venv\Scripts\activate
-```
+    ```powershell
+    py -m venv .venv
+    .venv\Scripts\Activate.ps1
+    ```
 
-O terminal deve mostrar `(venv)` no início da linha quando estiver ativado.
-
-### 3. Instalar as dependências
+Instale as dependências:
 
 ```bash
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
-### 4. Configurar as variáveis de ambiente
+## Conectar ao Neon
+
+Crie o `.env`:
 
 ```bash
 cp .env.example .env
 ```
 
-Abra o `.env` e altere os valores:
+No Windows, use `copy .env.example .env`.
+
+Solicite a connection string ao responsável pelo banco e preencha:
 
 ```env
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=legiskids
-DB_USER=postgres
-DB_PASSWORD=sua_senha_aqui
-FLASK_APP=src/backend/app.py
-FLASK_ENV=development
-SECRET_KEY=qualquer-string-longa-e-aleatoria
-PYTHONPATH=/caminho/absoluto/para/2026-1-LegisKids
+DATABASE_URL=postgresql://<usuario>:<senha>@<host>.neon.tech/<banco>?sslmode=require&channel_binding=require
+FLASK_ENV=testing
 ```
 
-> O `PYTHONPATH` precisa apontar para a raiz do projeto. No Linux/macOS você pode usar `pwd` dentro da pasta para descobrir o caminho completo.
+O modo `testing` é usado localmente para impedir que cada integrante inicie o
+scheduler diário no banco compartilhado.
 
-> O arquivo `.env` já está no `.gitignore` — suas credenciais nunca vão para o repositório.
-
-### 5. Criar o banco de dados
-
-Execute uma única vez:
-
-**Linux/macOS:**
-```bash
-psql -U postgres -h localhost -c "CREATE DATABASE legiskids;"
-```
-
-**Windows (PowerShell como administrador):**
-```bash
-psql -U postgres -c "CREATE DATABASE legiskids;"
-```
-
-Para verificar se o banco foi criado:
-```bash
-psql -U postgres -h localhost -c "\l"
-```
-
-### 6. Criar as tabelas com Flask-Migrate
-
-> ⚠️ **Não use mais o `create_tables.sql` para criar o banco.** O Flask-Migrate é agora o responsável por isso. O SQL existe apenas como referência/documentação.
+## Iniciar e verificar o backend
 
 ```bash
-flask db upgrade
+python -m flask --app src/backend/app.py run --debug
 ```
 
-Esse comando lê os arquivos de migration em `migrations/versions/` e cria todas as tabelas automaticamente. É o único comando necessário — funciona em banco zerado.
-
-### 7. Validar a conexão com o banco
-
-```bash
-python test_db.py
-```
-
-Saída esperada:
-```
-✅  Conexão com o PostgreSQL estabelecida com sucesso!
-```
-
-### 8. Testar as tabelas
-
-```bash
-python src/backend/migrations/test_tables.py
-```
-
-Saída esperada:
-```
-═══════════════════════════════════════════════════════
-  LegisKids — Teste de tabelas do banco de dados
-═══════════════════════════════════════════════════════
-  ✅ Conexão com o banco estabelecida
-── 1. Verificando tabelas ───────────────────────────────
-  ✅ Tabela 'favoritos' existe
-  ✅ Tabela 'historico_consultas' existe
-  ✅ Tabela 'partidos' existe
-  ✅ Tabela 'proposicoes' existe
-  ✅ Tabela 'requisicoes_api' existe
-  ✅ Tabela 'tramitacoes' existe
-  ✅ Tabela 'usuarios' existe
-── 2. Verificando campo 'categoria' em proposicoes ─────
-  ✅ Campo 'categoria' existe em 'proposicoes'
-── 3. Testando inserção de dados ───────────────────────
-  ✅ Inseriu partido
-  ✅ Inseriu proposição com categoria
-  ✅ Inseriu tramitação
-  ✅ Inseriu usuário
-  ✅ Inseriu favorito
-  ✅ Inseriu histórico de consulta
-  ✅ Inseriu requisição de API
-── 4. Testando consultas e relacionamentos ──────────────
-  ✅ Consultou proposição
-  ✅ Campo categoria correto
-  ✅ Relacionamento partido OK
-  ✅ Relacionamento tramitações OK
-  ✅ Relacionamento favoritos OK
-  ✅ Relacionamento histórico OK
-── 5. Limpando dados de teste ──────────────────────────
-  ✅ Dados de teste descartados (rollback)
-═══════════════════════════════════════════════════════
-  RESULTADO: todos os testes passaram ✅
-═══════════════════════════════════════════════════════
-```
-
-### 9. Subir o servidor Flask
-
-```bash
-flask run
-```
-
-Acesse **http://localhost:5000/health** no navegador. A resposta esperada é:
+Acesse `http://127.0.0.1:5000/health`. A resposta esperada é:
 
 ```json
-{ "status": "ok", "database": "conectado" }
+{
+  "status": "ok",
+  "database": "conectado"
+}
 ```
 
----
+## Regras para o banco compartilhado
 
-## Como trabalhar com migrations nas próximas issues
+- Nunca commite ou compartilhe publicamente a `DATABASE_URL`.
+- Não execute migrations, seed ou sincronizações sem autorização.
+- Não altere dados manualmente pelo painel do Neon sem combinar com a equipe.
+- Confirme o ambiente antes de qualquer operação de escrita.
+- Informe imediatamente o responsável caso uma credencial seja exposta.
 
-### Se você alterar um modelo existente ou criar um novo
+## Migrations
 
-Sempre que modificar o `models.py` (adicionar campo, tabela, mudar tipo), gere uma nova migration:
+As migrations ficam em `migrations/versions/` e devem acompanhar mudanças nos
+models. A pessoa responsável pela alteração deve revisar o arquivo gerado e
+combinar sua aplicação no Neon.
+
+Comandos de manutenção, somente quando autorizados:
 
 ```bash
-# 1. Gera o arquivo de migration automaticamente
-flask db migrate -m "descricao da mudanca"
-
-# 2. Revise o arquivo gerado em migrations/versions/
-# Verifique se o que foi gerado faz sentido
-
-# 3. Aplica a migration no banco
-flask db upgrade
+python -m flask --app src/backend/app.py db migrate -m "descricao da mudanca"
+python -m flask --app src/backend/app.py db upgrade
 ```
 
-> ⚠️ **Sempre commite o arquivo de migration junto com a mudança no model.** Outros integrantes precisam dele para atualizar o banco local.
+## Modelos e documentação do schema
 
-### Se você puxou mudanças do git e o banco está desatualizado
-
-```bash
-flask db upgrade
-```
-
-Esse comando detecta automaticamente quais migrations ainda não foram aplicadas e roda só as novas.
-
-### Se precisar reverter uma migration
-
-```bash
-# Volta uma migration
-flask db downgrade
-
-# Volta até o início (banco zerado)
-flask db downgrade base
-```
-
-### Ver o histórico de migrations
-
-```bash
-flask db history
-```
-
----
-
-## Como usar os modelos nas próximas issues
-
-O `models.py` já está pronto para ser importado. O `db` deve ser importado de `database.py`, não de `app.py`.
-
-### Inserir dados via Python
-
-```python
-from src.backend.app import app
-from src.backend.database import db
-from src.backend.models import Partido, Proposicao
-
-with app.app_context():
-    partido = Partido(id=36844, sigla="PT", nome="Partido dos Trabalhadores")
-    db.session.add(partido)
-    db.session.commit()
-```
-
-### Consultar dados
-
-```python
-from src.backend.app import app
-from src.backend.models import Proposicao
-
-with app.app_context():
-    # Todas as proposições
-    proposicoes = Proposicao.query.all()
-
-    # Filtrar por categoria
-    props_cyber = Proposicao.query.filter_by(categoria="cyberbullying").all()
-
-    # Filtrar por ano
-    props_2024 = Proposicao.query.filter_by(ano=2024).all()
-```
-
-### Usar no repository (camada de acesso ao banco)
-
-```python
-# src/backend/repository/proposicao_repository.py
-from src.backend.database import db
-from src.backend.models import Proposicao
-
-def buscar_todas():
-    return Proposicao.query.all()
-
-def buscar_por_id(id):
-    return Proposicao.query.get(id)
-
-def inserir(proposicao: Proposicao):
-    db.session.add(proposicao)
-    db.session.commit()
-    return proposicao
-```
-
----
+Os models SQLAlchemy estão em `src/backend/models.py`. A descrição das tabelas,
+relacionamentos e o diagrama estão na
+[documentação do schema](../../db/schema.md).
 
 ## Comandos do dia a dia
 
 | Situação | Comando |
 |---|---|
-| Abrir o projeto | `source venv/bin/activate` (Linux/Mac) ou `venv\Scripts\activate` (Windows) |
-| Alguém adicionou pacotes | `pip install -r requirements.txt` |
-| Subir o servidor | `flask run` |
-| Testar conexão com o banco | `python test_db.py` |
-| Testar as tabelas | `python src/backend/migrations/test_tables.py` |
-| Criar tabelas / atualizar banco | `flask db upgrade` |
-| Reverter última migration | `flask db downgrade` |
-| Gerar nova migration após mudar model | `flask db migrate -m "descricao"` |
-| Ver histórico de migrations | `flask db history` |
-| Visualizar a documentação | `mkdocs serve` |
-
----
+| Ativar o ambiente | `source .venv/bin/activate` |
+| Instalar dependências | `python -m pip install -r requirements.txt` |
+| Iniciar a API local | `python -m flask --app src/backend/app.py run --debug` |
+| Verificar a conexão | acessar `http://127.0.0.1:5000/health` |
 
 ## Problemas comuns
 
-**`ModuleNotFoundError: No module named 'flask'`**
-O venv não está ativado. Rode `source venv/bin/activate` e tente novamente.
+### `DATABASE_URL não configurada`
 
-**`externally-managed-environment`**
-Você está tentando instalar pacotes fora do venv. Ative o venv primeiro.
+Crie o `.env` a partir do exemplo e adicione a connection string fornecida
+pela equipe.
 
-**`python3 -m venv venv` falha**
-Instale o pacote necessário: `sudo apt install python3-full python3-venv -y`
+### Falha de autenticação ou SSL
 
-**`Peer authentication failed for user "postgres"`**
-Adicione `-h localhost` ao comando psql: `psql -U postgres -h localhost ...`
+Copie novamente a connection string completa pelo painel do Neon. Não remova
+os parâmetros `sslmode` e `channel_binding`.
 
-**`Error: No such command 'db'`**
-O Flask não está encontrando o app. Verifique se o `.env` tem `FLASK_APP=src/backend/app.py` e `PYTHONPATH` apontando para a raiz do projeto.
+### O healthcheck funciona, mas a API não retorna dados
 
-**`No changes in schema detected` ao rodar `flask db migrate`**
-O Alembic não está enxergando os models. Verifique se o `PYTHONPATH` está configurado no `.env` e se o `app.py` importa os models corretamente.
-
-**Erro de conexão com o banco**
-Verifique se o PostgreSQL está rodando e se a senha no `.env` bate com a do seu usuário `postgres`.
-
-**Banco desatualizado após puxar mudanças do git**
-Rode `flask db upgrade` para aplicar as migrations novas.
+O healthcheck verifica apenas a conexão. Comunique o responsável pelo banco
+para conferir schema e dados; não execute migrations ou seed por conta própria.


### PR DESCRIPTION
## O que foi feito?

- Reorganizado o README com instruções separadas para backend, frontend e documentação;
- Padronizadas as portas utilizadas pela aplicação;
- Atualizado o Neon como banco de dados padrão do projeto;
- Removidas as instruções de Docker dos guias ativos;
- Atualizados o `.env.example` e os guias de banco de dados;
- Corrigido o comando de execução da API no CONTRIBUTING;
- Adicionadas orientações de segurança para migrations, seed e credenciais;
- Configurado `FLASK_ENV=testing` no ambiente local para evitar o scheduler no banco compartilhado.

## Por que isso foi feito?

As instruções anteriores estavam duplicadas e apresentavam comandos conflitantes. O objetivo é oferecer um fluxo de configuração claro, seguro e alinhado ao ambiente Neon utilizado pela equipe.

## Como testar?

```bash
python -m pip install -r requirements-docs.txt
python -m mkdocs build --strict

cd src/frontend
npm install
npm run build