### PR TITLE
Fix/sync camara logging upsert quota

### DIFF
--- a/openspec/changes/sync-camara-gemini-batch-queue/design.md
+++ b/openspec/changes/sync-camara-gemini-batch-queue/design.md
@@ -1,0 +1,113 @@
+# Design — sync-camara-gemini-batch-queue
+
+## Fluxo atual vs. fluxo proposto
+
+### Atual (classifica por página)
+
+```
+Página 1 → filtra → 3 DTOs → Gemini(3) → persiste
+Página 2 → filtra → 1 DTO  → Gemini(1) → persiste
+Página 3 → filtra → 5 DTOs → Gemini(5) → persiste
+...
+Total: N páginas = N chamadas ao Gemini (com lotes menores que BATCH_SIZE)
+```
+
+### Proposto (fila acumulada)
+
+```
+Página 1 → filtra → 3 DTOs → fila=[3]
+Página 2 → filtra → 1 DTO  → fila=[4]
+Página 3 → filtra → 5 DTOs → fila=[9]
+Página 4 → filtra → 2 DTOs → fila=[11] → Gemini(10) → persiste → fila=[1]
+...
+Fim da paginação → Gemini(fila restante) → persiste
+```
+
+Com `GEMINI_BATCH_SIZE=10`, o número de chamadas ao Gemini cai de `ceil(total_relevantes / média_por_página)` para `ceil(total_relevantes / BATCH_SIZE)`.
+
+## Mudança em `run_sync()`
+
+### Estrutura da fila
+
+```python
+fila_dtos: list[dict] = []  # acumula DTOs válidos e novos entre páginas
+```
+
+A variável existe fora do `while True` e persiste entre iterações.
+
+### Loop de paginação (novo)
+
+```python
+while True:
+    # ... busca, early-stop, filtra, valida, remove conhecidos (inalterados) ...
+
+    dtos_validos = [dto for dto in dtos_validos if dto["id"] not in ids_conhecidos]
+    fila_dtos.extend(dtos_validos)
+    total_processados += len(filtrados)
+
+    # Drena a fila em lotes completos
+    while len(fila_dtos) >= self._batch_size:
+        lote = fila_dtos[:self._batch_size]
+        fila_dtos = fila_dtos[self._batch_size:]
+        _classificar_e_persistir_lote(lote)  # ver abaixo
+
+    pagina += 1
+
+# Drena o restante da fila (lote incompleto final)
+if fila_dtos:
+    _classificar_e_persistir_lote(fila_dtos)
+```
+
+### Extração de `_classificar_e_persistir_lote`
+
+Para não duplicar o bloco de classificação + persistência, o código atual (que já existe dentro do loop) é extraído para um bloco inline ou método privado:
+
+```python
+def _classificar_e_persistir_lote(self, lote: list[dict]) -> tuple[int, int, int]:
+    """Classifica um lote via Gemini e persiste. Retorna (inseridos, atualizados, descartados)."""
+    if cota_gemini_esgotada:
+        for dto in lote:
+            dto["classificacao_status"] = Proposicao.CLASSIFICACAO_PENDENTE
+        pares = [(dto, None) for dto in lote]
+    else:
+        pares = self._classificar_lote(lote)
+        if all(categorias is None for _, categorias in pares):
+            # sinaliza externamente via retorno ou flag compartilhada
+            ...
+
+    para_persistir = [(dto, cat) for dto, cat in pares if cat != [RESULTADO_IRRELEVANTE]]
+    descartados = len(pares) - len(para_persistir)
+
+    if para_persistir:
+        dtos_apenas = [d for d, _ in para_persistir]
+        contadores = repo.upsert_proposicoes_lote(dtos_apenas)
+        for dto, categorias in para_persistir:
+            if categorias:
+                repo.vincular_categorias_lote(dto["id"], categorias)
+        return contadores["inseridos"], contadores["atualizados"], descartados
+
+    return 0, 0, descartados
+```
+
+> **Nota de implementação**: `cota_gemini_esgotada` é uma variável de estado do `run_sync()`. O método auxiliar pode receber a flag como parâmetro e retornar se deve ser marcada como esgotada — ou pode-se manter a lógica inline dentro de `run_sync()` com uma função local (`nonlocal`), dependendo da clareza preferida.
+
+## Invariantes preservados
+
+| Invariante | Como é preservado |
+|---|---|
+| Early-stop por IDs conhecidos | Inalterado — ocorre antes de adicionar à fila |
+| Proposições irrelevantes não persistidas | Inalterado — `_classificar_lote` retorna `[RESULTADO_IRRELEVANTE]` e são filtradas antes do upsert |
+| `cota_gemini_esgotada` para de chamar Gemini no run | Preservado — verificado antes de cada lote drenado da fila |
+| Retry de pendentes no início do run | Inalterado — `_retentar_pendentes()` roda antes do loop |
+| `SyncExecution` registrada com totais corretos | Preservado — contadores acumulados da mesma forma |
+
+## Impacto em chamadas ao Gemini
+
+Dado `GEMINI_BATCH_SIZE=10` e uma run típica com 30 proposições relevantes espalhadas em 15 páginas (média 2/página):
+
+| Modelo | Chamadas ao Gemini |
+|---|---|
+| Atual | 15 (uma por página com proposições) |
+| Proposto | 3 (lotes de 10 completos) |
+
+Redução de 80% nas chamadas — dentro do limite de 20/dia do free tier com mais margem.

--- a/openspec/changes/sync-camara-gemini-batch-queue/proposal.md
+++ b/openspec/changes/sync-camara-gemini-batch-queue/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+O fluxo atual de `run_sync()` chama o Gemini **dentro do loop de páginas da API da Câmara**: a cada página, as proposições que passam pelo filtro de palavras-chave (geralmente 2 a 10 de 100) são imediatamente enviadas ao Gemini em lotes de `GEMINI_BATCH_SIZE`. Isso resulta em lotes menores do que o configurado na maioria dos casos — uma página que produz 3 proposições relevantes gera uma chamada ao Gemini com apenas 3 ementas, desperdiçando a capacidade do lote.
+
+O problema é relevante porque o Gemini free tier tem limite de **20 requisições/dia** (`GenerateRequestsPerDayPerProjectPerModel-FreeTier`). Cada chamada subutilizada é cota perdida. Uma run que processa 10 páginas com 3 proposições relevantes cada faz 10 chamadas para classificar 30 proposições — o mesmo resultado poderia ser obtido com 3 chamadas de 10.
+
+## What Changes
+
+- **`camara_service.py` — `run_sync()`**: substituir o modelo "classifica por página" por uma fila acumulada. As proposições válidas e novas são coletadas de todas as páginas em uma lista. Quando essa lista atinge `GEMINI_BATCH_SIZE`, o lote completo é enviado ao Gemini e persistido. O restante que não completou um lote é processado ao final da paginação.
+
+Nenhuma outra camada é afetada: repository, models, scheduler, frontend e banco de dados permanecem intactos.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `camara-sync-job`: o loop de paginação agora acumula DTOs em uma fila antes de enviar ao Gemini, em vez de classificar por página. O comportamento externo (proposições classificadas no banco, `SyncExecution` registrada) é idêntico; apenas a cadência das chamadas ao Gemini muda.
+
+### Non-goals
+
+- Não altera a lógica de retry de pendentes (`_retentar_pendentes`).
+- Não altera o prompt do Gemini nem o parsing da resposta.
+- Não introduz persistência assíncrona nem filas externas (Redis, Celery etc.).
+- Não altera a lógica de early-stop por IDs já conhecidos.
+
+## Impact
+
+- **Backend**: mudança cirúrgica em `camara_service.py`, apenas no método `run_sync()`.
+- **Banco de dados**: sem impacto — o comportamento do upsert e do vínculo de categorias é o mesmo.
+- **Gemini**: redução do número de chamadas à API proporcional ao grau de esparsidade das proposições relevantes por página.

--- a/openspec/changes/sync-camara-gemini-batch-queue/tasks.md
+++ b/openspec/changes/sync-camara-gemini-batch-queue/tasks.md
@@ -1,0 +1,20 @@
+## 1. Refatorar `run_sync()` para fila acumulada
+
+- [x] 1.1 Declarar `fila_dtos: list[dict] = []` antes do `while True` em `run_sync()`
+- [x] 1.2 Remover o bloco `for i in range(0, len(dtos_validos), self._batch_size)` que classifica dentro do loop de páginas
+- [x] 1.3 Substituir pelo acúmulo: `fila_dtos.extend(dtos_validos)` após o filtro de IDs conhecidos
+- [x] 1.4 Adicionar `while len(fila_dtos) >= self._batch_size:` para drenar lotes completos dentro do loop de páginas, reutilizando a lógica de classificação + persistência já existente
+- [x] 1.5 Após o `while True`, drenar o restante da fila (`if fila_dtos:`) com o mesmo bloco de classificação + persistência
+
+## 2. Consolidar lógica de classificação + persistência
+
+- [x] 2.1 Extrair o bloco de "classifica lote → filtra irrelevantes → upsert → vincula categorias" para um método privado `_processar_lote(self, lote, cota_esgotada) -> tuple[int, int, int, bool]` que retorna `(inseridos, atualizados, descartados, cota_agora_esgotada)`
+- [x] 2.2 Substituir as duas chamadas ao bloco (lote completo e lote final) pela chamada ao novo método
+- [x] 2.3 Garantir que `total_inseridos`, `total_atualizados`, `total_descartados` e `cota_gemini_esgotada` são acumulados corretamente a partir dos retornos do método
+
+## 3. Testes
+
+- [x] 3.1 Testar que proposições de múltiplas páginas são acumuladas antes de chamar o Gemini: mockar `_classificar_lote` e verificar que só é chamado quando `len(fila) >= BATCH_SIZE` ou ao fim da paginação
+- [x] 3.2 Testar o lote residual (proposições que não completam um lote cheio): verificar que são classificadas e persistidas após a paginação terminar
+- [x] 3.3 Testar que `cota_gemini_esgotada=True` faz os lotes restantes na fila serem marcados como `pendente_classificacao` sem chamar o Gemini
+- [x] 3.4 Testar que os totais (`total_inseridos`, `total_descartados`) acumulam corretamente ao longo de múltiplos drenos da fila

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -46,6 +46,12 @@ if os.getenv("FLASK_ENV") != "testing":
 @app.cli.command("sync-camara")
 def sync_camara():
     """Executa sincronização manual de proposições da Câmara dos Deputados."""
+    import logging as _logging
+    _logging.basicConfig(
+        level=_logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
     from src.backend.services.camara_service import CamaraService
     click.echo("Iniciando sincronização...")
     resumo = CamaraService().run_sync()

--- a/src/backend/repository/camara_repository.py
+++ b/src/backend/repository/camara_repository.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 
 from src.backend.database import db
 from src.backend.models import Categoria, Proposicao, SyncExecution, proposicao_categoria
@@ -173,22 +174,31 @@ def upsert_proposicoes_lote(dtos: list[dict]) -> dict:
         for row in db.session.query(Proposicao.id).filter(Proposicao.id.in_(ids)).all()
     }
 
-    with db.session.begin_nested():
-        for dto in dtos:
-            stmt = (
-                pg_insert(Proposicao.__table__)
-                .values(**dto)
-                .on_conflict_do_update(
-                    index_elements=["id"],
-                    set_={col: dto[col] for col in dto if col != "id"},
-                )
+    inseridos = 0
+    atualizados = 0
+    for dto in dtos:
+        stmt = (
+            pg_insert(Proposicao.__table__)
+            .values(**dto)
+            .on_conflict_do_update(
+                index_elements=["id"],
+                set_={col: dto[col] for col in dto if col != "id"},
             )
-            db.session.execute(stmt)
+        )
+        try:
+            with db.session.begin_nested():
+                db.session.execute(stmt)
+            if dto["id"] in existing_ids:
+                atualizados += 1
+            else:
+                inseridos += 1
+        except IntegrityError:
+            logger.warning(
+                "Proposição %d ignorada: conflito em (sigla_tipo=%s, numero=%d, ano=%d) já existe com outro id.",
+                dto["id"], dto["sigla_tipo"], dto["numero"], dto["ano"],
+            )
 
     db.session.commit()
-
-    inseridos = sum(1 for d in dtos if d["id"] not in existing_ids)
-    atualizados = sum(1 for d in dtos if d["id"] in existing_ids)
     return {"inseridos": inseridos, "atualizados": atualizados}
 
 

--- a/src/backend/services/camara_service.py
+++ b/src/backend/services/camara_service.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import os
 import time
@@ -156,6 +157,54 @@ def _filtrar_por_palavras_chave(dados: list[dict]) -> list[dict]:
     ]
 
 
+# ── Gemini rate limiter ───────────────────────────────────────────────────────
+
+_gemini_call_timestamps: collections.deque[float] = collections.deque()
+_gemini_daily_calls: int = 0
+_gemini_daily_date: date | None = None
+
+
+def _gemini_acquire(rpm: int, rpd: int) -> None:
+    """Bloqueia até que uma chamada ao Gemini possa ser feita respeitando RPM e RPD.
+
+    Lança RuntimeError com mensagem de quota diária se o limite RPD foi atingido,
+    compatível com _is_daily_quota_error para acionar o fluxo de cota esgotada.
+    """
+    global _gemini_daily_calls, _gemini_daily_date
+
+    today = date.today()
+    if _gemini_daily_date != today:
+        _gemini_daily_date = today
+        _gemini_daily_calls = 0
+
+    if _gemini_daily_calls >= rpd:
+        raise RuntimeError(
+            f"GenerateRequestsPerDayPerProjectPerModel-FreeTier: "
+            f"quota diária de {rpd} req/dia atingida (rate limiter local)."
+        )
+
+    # Janela deslizante de 60 s para o limite de RPM
+    now = time.monotonic()
+    while _gemini_call_timestamps and now - _gemini_call_timestamps[0] >= 60.0:
+        _gemini_call_timestamps.popleft()
+
+    if len(_gemini_call_timestamps) >= rpm:
+        wait = 60.0 - (now - _gemini_call_timestamps[0]) + 0.2
+        logger.info(
+            "Gemini RPM atingido (%d/%d req/min). Aguardando %.1fs.",
+            len(_gemini_call_timestamps), rpm, wait,
+        )
+        time.sleep(wait)
+        now = time.monotonic()
+        while _gemini_call_timestamps and now - _gemini_call_timestamps[0] >= 60.0:
+            _gemini_call_timestamps.popleft()
+
+    _gemini_call_timestamps.append(now)
+    _gemini_daily_calls += 1
+    logger.debug("Gemini: chamada %d/%d no dia, %d/%d no último minuto.",
+                 _gemini_daily_calls, rpd, len(_gemini_call_timestamps), rpm)
+
+
 # ── Gemini ────────────────────────────────────────────────────────────────────
 
 def _is_daily_quota_error(exc: Exception) -> bool:
@@ -196,6 +245,10 @@ def _classificar_lote_via_gemini(ementas: list[str]) -> list[list[str]]:
         raise RuntimeError("GOOGLE_API_KEY não configurada.")
 
     client = genai.Client(api_key=api_key)
+
+    rpm = int(os.getenv("GEMINI_RATE_LIMIT_RPM", "5"))
+    rpd = int(os.getenv("GEMINI_RATE_LIMIT_RPD", "20"))
+    _gemini_acquire(rpm, rpd)
 
     categorias_str = "\n".join(f"- {c}" for c in CATEGORIAS_FIXAS)
     ementas_formatadas = "\n".join(f"{i + 1}: {e[:400]}" for i, e in enumerate(ementas))

--- a/src/backend/services/camara_service.py
+++ b/src/backend/services/camara_service.py
@@ -115,6 +115,10 @@ def _validar_proposicao(dado: dict) -> dict | None:
         logger.warning("Proposição %s: ementa vazia. Ignorando.", dado.get("id"))
         return None
 
+    if int(dado["ano"]) <= 0:
+        logger.warning("Proposição %s: ano inválido '%s'. Ignorando.", dado.get("id"), dado.get("ano"))
+        return None
+
     data_apresentacao = _normalizar_data(dado.get("dataApresentacao"))
     if data_apresentacao is None:
         logger.warning(
@@ -153,6 +157,11 @@ def _filtrar_por_palavras_chave(dados: list[dict]) -> list[dict]:
 
 
 # ── Gemini ────────────────────────────────────────────────────────────────────
+
+def _is_daily_quota_error(exc: Exception) -> bool:
+    exc_str = str(exc).lower()
+    return "perday" in exc_str or "per_day" in exc_str or "generaterequestsperdayperproject" in exc_str
+
 
 def _is_rate_limit_error(exc: Exception) -> bool:
     exc_str = str(exc).lower()
@@ -217,6 +226,9 @@ def _classificar_lote_via_gemini(ementas: list[str]) -> list[list[str]]:
             )
             break
         except Exception as exc:
+            if _is_daily_quota_error(exc):
+                logger.warning("Gemini: quota diária esgotada — abortando classificação sem retry.")
+                raise
             if tentativa < 2 and _is_rate_limit_error(exc):
                 logger.warning("Gemini 429 ResourceExhausted: aguardando 60s antes de re-tentar.")
                 time.sleep(60)

--- a/src/backend/services/camara_service.py
+++ b/src/backend/services/camara_service.py
@@ -300,6 +300,38 @@ class CamaraService:
         """Wrapper single-item para compatibilidade interna."""
         return self._classificar_lote([dto])[0]
 
+    def _processar_lote(
+        self, lote: list[dict], cota_esgotada: bool
+    ) -> tuple[int, int, int, bool]:
+        """Classifica via Gemini (ou marca como pendente) e persiste o lote.
+
+        Retorna (inseridos, atualizados, descartados, cota_agora_esgotada).
+        """
+        if cota_esgotada:
+            for dto in lote:
+                dto["classificacao_status"] = Proposicao.CLASSIFICACAO_PENDENTE
+            pares: list[tuple[dict, list[str] | None]] = [(dto, None) for dto in lote]
+        else:
+            pares = self._classificar_lote(lote)
+            if all(categorias is None for _, categorias in pares):
+                cota_esgotada = True
+
+        para_persistir = [(dto, cat) for dto, cat in pares if cat != [RESULTADO_IRRELEVANTE]]
+        descartados = len(pares) - len(para_persistir)
+
+        inseridos = 0
+        atualizados = 0
+        if para_persistir:
+            dtos_apenas = [d for d, _ in para_persistir]
+            contadores = repo.upsert_proposicoes_lote(dtos_apenas)
+            inseridos = contadores["inseridos"]
+            atualizados = contadores["atualizados"]
+            for dto, categorias in para_persistir:
+                if categorias:
+                    repo.vincular_categorias_lote(dto["id"], categorias)
+
+        return inseridos, atualizados, descartados, cota_esgotada
+
     def _retentar_pendentes(self) -> None:
         """Re-classifica proposições com status pendente_classificacao em lotes."""
         pendentes = repo.get_proposicoes_pendentes(limite=50)
@@ -342,6 +374,7 @@ class CamaraService:
             # Re-tentar pendentes de runs anteriores antes de buscar novas proposições
             self._retentar_pendentes()
 
+            fila_dtos: list[dict] = []
             pagina = 1
             while True:
                 logger.info("Buscando página %d da API da Câmara...", pagina)
@@ -392,40 +425,26 @@ class CamaraService:
                 if pulados:
                     logger.debug("Página %d: %d proposição(ões) já no banco — ignoradas.", pagina, pulados)
 
-                dtos_com_resultado: list[tuple[dict, str | None]] = []
-                for i in range(0, len(dtos_validos), self._batch_size):
-                    lote = dtos_validos[i:i + self._batch_size]
-                    if cota_gemini_esgotada:
-                        for dto in lote:
-                            dto["classificacao_status"] = Proposicao.CLASSIFICACAO_PENDENTE
-                        dtos_com_resultado.extend((dto, None) for dto in lote)
-                        continue
-                    pares = self._classificar_lote(lote)
-                    dtos_com_resultado.extend(pares)
-                    # Gemini falhou em todo o lote (todos retornaram None) → parar de chamar neste run
-                    if all(categorias is None for _, categorias in pares):
-                        cota_gemini_esgotada = True
-
-                # Filtra irrelevantes e persiste o restante
-                para_persistir = []
-                for dto, categorias in dtos_com_resultado:
-                    if categorias == [RESULTADO_IRRELEVANTE]:
-                        total_descartados += 1
-                    else:
-                        para_persistir.append((dto, categorias))
-
-                if para_persistir:
-                    dtos_apenas = [d for d, _ in para_persistir]
-                    contadores = repo.upsert_proposicoes_lote(dtos_apenas)
-                    total_inseridos += contadores["inseridos"]
-                    total_atualizados += contadores["atualizados"]
-
-                    for dto, categorias in para_persistir:
-                        if categorias:
-                            repo.vincular_categorias_lote(dto["id"], categorias)
-
+                fila_dtos.extend(dtos_validos)
                 total_processados += len(filtrados)
+
+                # Drena lotes completos da fila acumulada entre páginas
+                while len(fila_dtos) >= self._batch_size:
+                    lote = fila_dtos[:self._batch_size]
+                    fila_dtos = fila_dtos[self._batch_size:]
+                    ins, atu, desc, cota_gemini_esgotada = self._processar_lote(lote, cota_gemini_esgotada)
+                    total_inseridos += ins
+                    total_atualizados += atu
+                    total_descartados += desc
+
                 pagina += 1
+
+            # Drena o lote residual (proposições que não completaram um lote cheio)
+            if fila_dtos:
+                ins, atu, desc, cota_gemini_esgotada = self._processar_lote(fila_dtos, cota_gemini_esgotada)
+                total_inseridos += ins
+                total_atualizados += atu
+                total_descartados += desc
 
         except Exception as exc:
             logger.exception("Erro interno inesperado na sincronização.")

--- a/tests/test_camara_service.py
+++ b/tests/test_camara_service.py
@@ -192,5 +192,148 @@ class TestClassificarEFiltrar(unittest.TestCase):
         self.assertEqual(dto["classificacao_status"], "pendente_classificacao")
 
 
+class TestRunSyncFilaAcumulada(unittest.TestCase):
+    """
+    Testa o comportamento de fila acumulada entre páginas no run_sync().
+    Tasks 3.1–3.4 do change sync-camara-gemini-batch-queue.
+    """
+
+    def _raw(self, id_):
+        return {
+            "id": id_,
+            "siglaTipo": "PL",
+            "numero": id_,
+            "ano": 2025,
+            "ementa": "proteção de dados de crianças na internet",
+            "dataApresentacao": "2025-01-15",
+            "descricaoSituacao": "Em tramitação",
+            "siglaPartido": "PT",
+        }
+
+    def _service(self, batch_size=10):
+        from src.backend.services.camara_service import CamaraService
+        svc = CamaraService()
+        svc._batch_size = batch_size
+        return svc
+
+    def _setup_criar(self, mock_criar):
+        mock_exec = MagicMock()
+        mock_exec.id = 1
+        mock_criar.return_value = mock_exec
+
+    def _classificar_ok(self, dtos):
+        for dto in dtos:
+            dto["classificacao_status"] = "classificado"
+        return [(dto, ["cyberbullying"]) for dto in dtos]
+
+    def _classificar_none(self, dtos):
+        return [(dto, None) for dto in dtos]
+
+    @patch("src.backend.services.camara_service.repo.get_proposicoes_pendentes", return_value=[])
+    @patch("src.backend.services.camara_service.repo.vincular_categorias_lote")
+    @patch("src.backend.services.camara_service.repo.upsert_proposicoes_lote",
+           return_value={"inseridos": 1, "atualizados": 0})
+    @patch("src.backend.services.camara_service.repo.get_ids_existentes", return_value=set())
+    @patch("src.backend.services.camara_service.repo.atualizar_sync_execution")
+    @patch("src.backend.services.camara_service.repo.criar_sync_execution")
+    @patch("src.backend.services.camara_service._buscar_proposicoes_api")
+    def test_3_1_acumula_multiplas_paginas_antes_do_gemini(
+        self, mock_api, mock_criar, mock_atualizar, mock_ids, mock_upsert, mock_vincular, mock_pendentes
+    ):
+        """Proposições de múltiplas páginas acumulam na fila antes de acionar _classificar_lote."""
+        self._setup_criar(mock_criar)
+        svc = self._service(batch_size=10)
+
+        page1 = [self._raw(i) for i in range(1, 5)]   # 4 proposições
+        page2 = [self._raw(i) for i in range(5, 11)]  # 6 → fila chega a 10 e drena
+        mock_api.side_effect = [page1, page2, []]
+
+        with patch.object(svc, "_classificar_lote", side_effect=self._classificar_ok) as mock_cl:
+            svc.run_sync()
+
+        self.assertEqual(mock_cl.call_count, 1, "deve ter uma única chamada ao Gemini com lote de 10")
+        args, _ = mock_cl.call_args
+        self.assertEqual(len(args[0]), 10)
+
+    @patch("src.backend.services.camara_service.repo.get_proposicoes_pendentes", return_value=[])
+    @patch("src.backend.services.camara_service.repo.vincular_categorias_lote")
+    @patch("src.backend.services.camara_service.repo.upsert_proposicoes_lote",
+           return_value={"inseridos": 1, "atualizados": 0})
+    @patch("src.backend.services.camara_service.repo.get_ids_existentes", return_value=set())
+    @patch("src.backend.services.camara_service.repo.atualizar_sync_execution")
+    @patch("src.backend.services.camara_service.repo.criar_sync_execution")
+    @patch("src.backend.services.camara_service._buscar_proposicoes_api")
+    def test_3_2_lote_residual_classificado_apos_paginacao(
+        self, mock_api, mock_criar, mock_atualizar, mock_ids, mock_upsert, mock_vincular, mock_pendentes
+    ):
+        """Proposições que não completam um lote cheio são classificadas após a paginação terminar."""
+        self._setup_criar(mock_criar)
+        svc = self._service(batch_size=10)
+
+        page1 = [self._raw(i) for i in range(1, 4)]  # 3 proposições — abaixo do BATCH_SIZE
+        mock_api.side_effect = [page1, []]
+
+        with patch.object(svc, "_classificar_lote", side_effect=self._classificar_ok) as mock_cl:
+            svc.run_sync()
+
+        self.assertEqual(mock_cl.call_count, 1, "lote residual deve ser classificado após paginação")
+        args, _ = mock_cl.call_args
+        self.assertEqual(len(args[0]), 3)
+
+    @patch("src.backend.services.camara_service.repo.get_proposicoes_pendentes", return_value=[])
+    @patch("src.backend.services.camara_service.repo.vincular_categorias_lote")
+    @patch("src.backend.services.camara_service.repo.upsert_proposicoes_lote",
+           return_value={"inseridos": 5, "atualizados": 0})
+    @patch("src.backend.services.camara_service.repo.get_ids_existentes", return_value=set())
+    @patch("src.backend.services.camara_service.repo.atualizar_sync_execution")
+    @patch("src.backend.services.camara_service.repo.criar_sync_execution")
+    @patch("src.backend.services.camara_service._buscar_proposicoes_api")
+    def test_3_3_cota_esgotada_pula_gemini_nos_lotes_seguintes(
+        self, mock_api, mock_criar, mock_atualizar, mock_ids, mock_upsert, mock_vincular, mock_pendentes
+    ):
+        """Quando o Gemini esgota a cota, lotes subsequentes marcam como pendente sem chamar o Gemini."""
+        self._setup_criar(mock_criar)
+        svc = self._service(batch_size=5)
+
+        page1 = [self._raw(i) for i in range(1, 6)]   # 5 → lote 1, quota esgota
+        page2 = [self._raw(i) for i in range(6, 11)]  # 5 → lote 2, deve pular Gemini
+        mock_api.side_effect = [page1, page2, []]
+
+        with patch.object(svc, "_classificar_lote", side_effect=self._classificar_none) as mock_cl:
+            svc.run_sync()
+
+        self.assertEqual(mock_cl.call_count, 1, "cota esgotada deve impedir chamadas subsequentes ao Gemini")
+
+    @patch("src.backend.services.camara_service.repo.get_proposicoes_pendentes", return_value=[])
+    @patch("src.backend.services.camara_service.repo.get_ids_existentes", return_value=set())
+    @patch("src.backend.services.camara_service.repo.atualizar_sync_execution")
+    @patch("src.backend.services.camara_service.repo.criar_sync_execution")
+    @patch("src.backend.services.camara_service._buscar_proposicoes_api")
+    def test_3_4_totais_acumulam_ao_longo_dos_lotes(
+        self, mock_api, mock_criar, mock_atualizar, mock_ids, mock_pendentes
+    ):
+        """total_inseridos e total_descartados acumulam corretamente de múltiplos drenos da fila."""
+        self._setup_criar(mock_criar)
+        svc = self._service(batch_size=5)
+
+        page1 = [self._raw(i) for i in range(1, 6)]    # 5 → lote 1
+        page2 = [self._raw(i) for i in range(6, 11)]   # 5 → lote 2
+        page3 = [self._raw(i) for i in range(11, 14)]  # 3 → residual
+        mock_api.side_effect = [page1, page2, page3, []]
+
+        processar_retornos = [
+            (3, 0, 2, False),  # lote 1: 3 inseridos, 2 descartados
+            (4, 0, 1, False),  # lote 2: 4 inseridos, 1 descartado
+            (2, 0, 1, False),  # residual: 2 inseridos, 1 descartado
+        ]
+
+        with patch.object(svc, "_processar_lote", side_effect=processar_retornos):
+            svc.run_sync()
+
+        kwargs = mock_atualizar.call_args[1]
+        self.assertEqual(kwargs["total_inseridos"], 9)    # 3 + 4 + 2
+        self.assertEqual(kwargs["total_descartados"], 4)  # 2 + 1 + 1
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_camara_service.py
+++ b/tests/test_camara_service.py
@@ -9,6 +9,9 @@ from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
 os.environ.setdefault("FLASK_ENV", "testing")
+# Desabilita o rate limiter do Gemini em testes (força override independente do shell)
+os.environ["GEMINI_RATE_LIMIT_RPM"] = "1000"
+os.environ["GEMINI_RATE_LIMIT_RPD"] = "10000"
 
 
 class TestValidarProposicao(unittest.TestCase):
@@ -65,6 +68,12 @@ class TestValidarProposicao(unittest.TestCase):
 
 class TestClassificarLoteViaGemini(unittest.TestCase):
     """Testa _classificar_lote_via_gemini — classificação em batch com múltiplas categorias."""
+
+    def setUp(self):
+        import src.backend.services.camara_service as svc_mod
+        svc_mod._gemini_call_timestamps.clear()
+        svc_mod._gemini_daily_calls = 0
+        svc_mod._gemini_daily_date = None
 
     def _mock_client(self, texto_resposta: str):
         mock_response = MagicMock()


### PR DESCRIPTION
## Contexto

O pipeline de sincronização com a API da Câmara (`camara_service.py`) apresentava três problemas práticos:

1. **Logging invisível** — logs não apareciam no CLI durante execuções manuais
2. **Upsert frágil** — falhas silenciosas ao persistir proposições em lote no banco
3. **Retry inútil após quota diária** — ao esgotar a cota do Gemini, o sistema continuava tentando novas chamadas, desperdiçando requisições e travando o run

Além disso, a variável `GEMINI_RATE_LIMIT_RPM` existia no `.env` mas não tinha implementação no código, e o modelo de classificação chamava o Gemini uma vez por página da API da Câmara — muito ineficiente para o free tier de 20 req/dia.

## O que foi feito

### Correções de robustez
- Logging configurado para ser visível no CLI durante runs manuais
- Upsert de proposições em lote tornado resiliente a falhas parciais
- Quota diária do Gemini detectada sem retry: ao receber o erro `GenerateRequestsPerDayPerProjectPerModel`, o pipeline marca todas as proposições restantes como `pendente_classificacao` e encerra a classificação sem desperdiçar mais chamadas

### Otimização do consumo do Gemini (fila acumulada)
- Substituído o modelo "classifica por página" por fila acumulada entre páginas
- Proposições válidas de múltiplas páginas se acumulam e só são enviadas ao Gemini quando a fila atinge `GEMINI_BATCH_SIZE` (ou ao final da paginação para o lote residual)
- Com `GEMINI_BATCH_SIZE=50` e o free tier de 20 req/dia: **1.000 proposições classificadas por dia** (vs ~200 antes)
- Redução de até 80% nas chamadas ao Gemini em runs típicas

### Rate limiting client-side
- Implementado `_gemini_acquire(rpm, rpd)` com:
  - **Janela deslizante de 60s** para o limite de RPM: dorme o tempo necessário antes de cada chamada
  - **Contador diário com reset automático** para o limite de RPD: lança erro compatível com o fluxo de `cota_gemini_esgotada` antes mesmo de chamar a API
- Variáveis `GEMINI_RATE_LIMIT_RPM=5` e `GEMINI_RATE_LIMIT_RPD=20` configuradas no `.env`

### Cobertura de testes
4 novos testes unitários em `TestRunSyncFilaAcumulada`:
- Acumulação de proposições entre páginas antes de acionar o Gemini
- Lote residual classificado após o fim da paginação
- `cota_esgotada=True` impede chamadas subsequentes ao Gemini
- Totais (`total_inseridos`, `total_descartados`) acumulam corretamente entre múltiplos lotes

## Arquivos modificados
- `src/backend/services/camara_service.py`
- `tests/test_camara_service.py`
- `openspec/changes/sync-camara-gemini-batch-queue/` (proposta, design e tasks)

## Relacionado
- Branch: `fix/sync-camara-logging-upsert-quota`