### PR TITLE
[fix]#subtema-status-Encerrado-e-código-de-proposição

### DIFF
--- a/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/design.md
+++ b/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/design.md
@@ -1,0 +1,26 @@
+## Context
+
+Três bugs de exibição foram identificados em componentes Vue já existentes (`FilterBar.vue`, `StatusBadge.vue`, `ProposicaoCard.vue`, `DetalheView.vue`). Todos os dados necessários (`sigla_tipo`, `numero`, `ano`, nome do tema) já chegam da API — não há mudança de contrato com o backend. O escopo é estritamente `src/frontend/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Corrigir o `v-for`/`:value` do select de subtema em `FilterBar.vue` para emitir o nome (string) do tema.
+- Cobrir o status `Encerrado` em `StatusBadge.vue` com a mesma classe visual de `Arquivado`.
+- Exibir o código legível da proposição (`sigla_tipo numero/ano`) em vez do `id` numérico em `ProposicaoCard.vue` e `DetalheView.vue`.
+
+**Non-Goals:**
+- Não alterar endpoints, models ou serviços do backend.
+- Não alterar a identidade visual, paleta de cores ou layout além do necessário para o badge `Encerrado`.
+- Não refatorar `FilterBar`, `StatusBadge`, `ProposicaoCard` ou `DetalheView` além das correções pontuais descritas.
+
+## Decisions
+
+- **FilterBar — vincular `:value` ao nome do tema**: trocar `:value="t"` por `:value="t.nome"` no `<option>` do select de subtema. Alternativa descartada: manter o objeto e extrair `.nome` no momento de emitir o evento — rejeitada por exigir lógica extra em múltiplos pontos do componente quando o fix na origem (o `<option>`) já resolve o problema de forma mínima.
+- **StatusBadge — reaproveitar classe de `Arquivado` para `Encerrado`**: adicionar `Encerrado` ao mesmo mapeamento/case que já resolve a cor cinza de `Arquivado`, em vez de criar uma nova classe CSS. Mantém a paleta institucional consistente e evita duplicação de estilo.
+- **Código legível da proposição**: usar diretamente `{{ proposicao.sigla_tipo }} {{ proposicao.numero }}/{{ proposicao.ano }}` no template, sem criar um computed/helper novo, já que a formatação é usada em apenas dois pontos (`ProposicaoCard.vue`, `DetalheView.vue`) e não há lógica condicional além da concatenação.
+
+## Risks / Trade-offs
+
+- [Campos `sigla_tipo`/`numero`/`ano` ausentes ou nulos em algum registro legado] → manter fallback visual equivalente ao já existente para outros campos ausentes em `ProposicaoCard` (ex.: exibir vazio/traço em vez de quebrar a renderização).
+- [Outros valores de status não mapeados além de `Encerrado`] → fora do escopo desta mudança; não alterar o tratamento padrão/fallback já existente em `StatusBadge`.

--- a/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/proposal.md
+++ b/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Três bugs visuais no frontend (Vue) estão degradando a experiência de busca e visualização de proposições: o filtro de subtema envia o objeto inteiro em vez do nome (quebrando a filtragem), o badge de status não reconhece o valor "Encerrado" (renderiza sem estilo), e cards/detalhes exibem o `id` numérico interno em vez do código legível da proposição (`sigla_tipo numero/ano`). São correções pontuais, sem mudança de arquitetura, restritas a `src/frontend/`.
+
+## What Changes
+
+- Corrigir `FilterBar.vue` para vincular o `<option>` de subtema ao nome (`t.nome`) em vez do objeto `t`, garantindo que `filter-changed` emita uma string e não `[object Object]`.
+- Adicionar o status `Encerrado` ao mapeamento de cores de `StatusBadge.vue`, reaproveitando a mesma classe/cor cinza já usada para `Arquivado`.
+- Substituir a exibição do `id` numérico pelo código legível (`sigla_tipo numero/ano`) em `ProposicaoCard.vue` e `DetalheView.vue`, usando os campos `sigla_tipo`, `numero` e `ano` já retornados pela API.
+
+## Capabilities
+
+### New Capabilities
+(nenhuma)
+
+### Modified Capabilities
+- `vue-components-ui`: `FilterBar` deve emitir o nome do subtema (string) e não o objeto tema; `StatusBadge` deve estilizar o status `Encerrado` igual a `Arquivado`; `ProposicaoCard` deve exibir o código legível da proposição (`sigla_tipo numero/ano`) em vez do `id` numérico.
+
+## Impact
+
+- Código afetado: `src/frontend/src/components/FilterBar.vue`, `src/frontend/src/components/StatusBadge.vue`, `src/frontend/src/components/ProposicaoCard.vue`, `src/frontend/src/views/DetalheView.vue`.
+- Nenhum endpoint, modelo ou rota de backend é alterado.
+- Sem novas dependências.

--- a/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/specs/vue-components-ui/spec.md
+++ b/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/specs/vue-components-ui/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Componente ProposicaoCard
+O sistema SHALL possuir `src/components/ProposicaoCard.vue` que recebe via props os campos `titulo`, `autor`, `partido`, `data`, `status`, `subtema`, `id`, `sigla_tipo`, `numero` e `ano`, e os renderiza como card clicável que navega para `/proposicao/:id`. O card SHALL exibir o código legível da proposição no formato `sigla_tipo numero/ano` (ex.: "PL 1234/2023") em vez do `id` numérico interno.
+
+#### Scenario: Card renderizado com dados completos
+- **WHEN** o componente recebe todos os campos da proposição
+- **THEN** exibe o código no formato `sigla_tipo numero/ano`, título, autor, partido, data formatada e badge de status com cor correspondente
+
+#### Scenario: Campo ausente tratado com fallback
+- **WHEN** o campo `autor` não está presente nos dados
+- **THEN** exibe "Autor não informado" sem quebrar a renderização
+
+#### Scenario: Clique no card navega para detalhes
+- **WHEN** o usuário clica no card
+- **THEN** o Vue Router navega para `/proposicao/:id` sem reload da página
+
+### Requirement: Componente FilterBar
+O sistema SHALL possuir `src/components/FilterBar.vue` que renderiza os controles de filtro e emite evento `filter-changed` com os valores atuais quando qualquer filtro muda (US09). O filtro de subtema SHALL emitir o nome do tema (string), nunca o objeto tema completo.
+
+#### Scenario: Filtros emitem evento ao mudar
+- **WHEN** o usuário seleciona um partido no select
+- **THEN** o componente emite `filter-changed` com objeto `{ partido: 'PT', ... }`
+
+#### Scenario: Filtro de subtema emite o nome como string
+- **WHEN** o usuário seleciona um subtema no select
+- **THEN** o componente emite `filter-changed` com `{ subtema: '<nome do tema>', ... }`, nunca com o objeto tema (`[object Object]`)
+
+#### Scenario: Filtros ativos exibidos como tags removíveis
+- **WHEN** existem filtros ativos
+- **THEN** cada filtro ativo é exibido como tag com botão "×" para remoção individual
+
+#### Scenario: Botão limpar filtros
+- **WHEN** o usuário clica em "Limpar filtros"
+- **THEN** todos os filtros são resetados e o evento `filter-changed` é emitido com valores padrão
+
+### Requirement: Componente StatusBadge
+O sistema SHALL possuir `src/components/StatusBadge.vue` que recebe um `status` (string) via prop e renderiza um badge colorido seguindo a paleta institucional. O status `Encerrado` SHALL usar a mesma cor/classe (cinza) já usada para `Arquivado`.
+
+#### Scenario: Badge colorido por status
+- **WHEN** a prop `status` é "Aprovado"
+- **THEN** o badge exibe "Aprovado" com fundo verde (usando variável CSS da paleta)
+
+#### Scenario: Badge para status Encerrado
+- **WHEN** a prop `status` é "Encerrado"
+- **THEN** o badge exibe "Encerrado" com a mesma cor/classe cinza usada para "Arquivado"

--- a/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/tasks.md
+++ b/openspec/changes/archive/2026-06-30-fix-frontend-display-bugs/tasks.md
@@ -1,0 +1,25 @@
+## 1. Filtro de subtema (FilterBar.vue)
+
+- [x] 1.1 Em `src/frontend/src/components/FilterBar.vue`, trocar `:value="t"` por `:value="t.nome"` no `<option v-for="t in temas">` do select de subtema
+- [x] 1.2 Confirmar que `filter-changed` passa a emitir `{ subtema: '<nome>', ... }` (string), nunca o objeto tema
+
+## 2. Badge de status "Encerrado" (StatusBadge.vue)
+
+- [x] 2.1 Em `src/frontend/src/components/StatusBadge.vue`, adicionar o caso `Encerrado` ao mapeamento de classes/cores, reaproveitando a mesma cor cinza de `Arquivado`
+- [x] 2.2 Confirmar visualmente que o badge `Encerrado` renderiza com a cor cinza e não cai no fallback sem estilo
+
+## 3. Código legível da proposição (ProposicaoCard.vue, DetalheView.vue)
+
+- [x] 3.1 Em `src/frontend/src/components/ProposicaoCard.vue`, substituir a exibição do `id` numérico por `{{ proposicao.sigla_tipo }} {{ proposicao.numero }}/{{ proposicao.ano }}`
+- [x] 3.2 Em `src/frontend/src/views/DetalheView.vue`, aplicar a mesma substituição do `id` numérico pelo formato `sigla_tipo numero/ano`
+- [x] 3.3 Verificar que o `id` continua sendo usado internamente (rota `/proposicao/:id`, key de lista) e que apenas a exibição visual muda
+
+## 4. Validação
+
+- [x] 4.1 Rodar o frontend localmente (`npm run dev`) e validar manualmente: filtro de subtema funcionando, badge "Encerrado" estilizado, código da proposição exibido em card e na tela de detalhes
+- [x] 4.2 Rodar lint/build do frontend (`npm run build` ou equivalente) para garantir que não há erros de template
+
+## 5. Robustez na exibição de partido (BuscaView.vue, DetalheView.vue)
+
+- [x] 5.1 Causa raiz identificada: `sigla_partido` chega sempre vazio do backend (ETL não busca `siglaPartido`, que não existe na listagem da API da Câmara — precisa do endpoint de autores). Fix de dado fica fora do escopo desta branch (frontend-only); registrado para change de backend futura.
+- [x] 5.2 Em `BuscaView.vue` e `DetalheView.vue`, adicionar `partidoLabel`/`partidoLabel(p)` que lê tanto `partido` (objeto `{sigla, nome}`, quando o backend popular o relacionamento) quanto `sigla_partido` (string), evitando que o card/detalhe exiba `[object Object]` quando o backend for corrigido

--- a/openspec/specs/vue-components-ui/spec.md
+++ b/openspec/specs/vue-components-ui/spec.md
@@ -20,11 +20,11 @@ Componentes em `src/components/`: Navbar (navegação responsiva), StatusBadge (
 ## Requisitos
 
 ### Requirement: Componente ProposicaoCard
-O sistema SHALL possuir `src/components/ProposicaoCard.vue` que recebe via props os campos `titulo`, `autor`, `partido`, `data`, `status`, `subtema` e `id` e os renderiza como card clicável que navega para `/proposicao/:id`.
+O sistema SHALL possuir `src/components/ProposicaoCard.vue` que recebe via props os campos `titulo`, `autor`, `partido`, `data`, `status`, `subtema`, `id`, `sigla_tipo`, `numero` e `ano`, e os renderiza como card clicável que navega para `/proposicao/:id`. O card SHALL exibir o código legível da proposição no formato `sigla_tipo numero/ano` (ex.: "PL 1234/2023") em vez do `id` numérico interno.
 
 #### Scenario: Card renderizado com dados completos
 - **WHEN** o componente recebe todos os campos da proposição
-- **THEN** exibe título, autor, partido, data formatada e badge de status com cor correspondente
+- **THEN** exibe o código no formato `sigla_tipo numero/ano`, título, autor, partido, data formatada e badge de status com cor correspondente
 
 #### Scenario: Campo ausente tratado com fallback
 - **WHEN** o campo `autor` não está presente nos dados
@@ -35,11 +35,15 @@ O sistema SHALL possuir `src/components/ProposicaoCard.vue` que recebe via props
 - **THEN** o Vue Router navega para `/proposicao/:id` sem reload da página
 
 ### Requirement: Componente FilterBar
-O sistema SHALL possuir `src/components/FilterBar.vue` que renderiza os controles de filtro e emite evento `filter-changed` com os valores atuais quando qualquer filtro muda (US09).
+O sistema SHALL possuir `src/components/FilterBar.vue` que renderiza os controles de filtro e emite evento `filter-changed` com os valores atuais quando qualquer filtro muda (US09). O filtro de subtema SHALL emitir o nome do tema (string), nunca o objeto tema completo.
 
 #### Scenario: Filtros emitem evento ao mudar
 - **WHEN** o usuário seleciona um partido no select
 - **THEN** o componente emite `filter-changed` com objeto `{ partido: 'PT', ... }`
+
+#### Scenario: Filtro de subtema emite o nome como string
+- **WHEN** o usuário seleciona um subtema no select
+- **THEN** o componente emite `filter-changed` com `{ subtema: '<nome do tema>', ... }`, nunca com o objeto tema (`[object Object]`)
 
 #### Scenario: Filtros ativos exibidos como tags removíveis
 - **WHEN** existem filtros ativos
@@ -65,11 +69,15 @@ O sistema SHALL possuir `src/components/Pagination.vue` que recebe `totalItems`,
 - **THEN** o botão da página 3 tem classe CSS ativa e está desabilitado para clique
 
 ### Requirement: Componente StatusBadge
-O sistema SHALL possuir `src/components/StatusBadge.vue` que recebe um `status` (string) via prop e renderiza um badge colorido seguindo a paleta institucional.
+O sistema SHALL possuir `src/components/StatusBadge.vue` que recebe um `status` (string) via prop e renderiza um badge colorido seguindo a paleta institucional. O status `Encerrado` SHALL usar a mesma cor/classe (cinza) já usada para `Arquivado`.
 
 #### Scenario: Badge colorido por status
 - **WHEN** a prop `status` é "Aprovado"
 - **THEN** o badge exibe "Aprovado" com fundo verde (usando variável CSS da paleta)
+
+#### Scenario: Badge para status Encerrado
+- **WHEN** a prop `status` é "Encerrado"
+- **THEN** o badge exibe "Encerrado" com a mesma cor/classe cinza usada para "Arquivado"
 
 ### Requirement: Componente LoadingSpinner
 O sistema SHALL possuir `src/components/LoadingSpinner.vue` que exibe indicador de carregamento acessível com `role="status"` e `aria-label="Carregando..."`.

--- a/src/frontend/src/components/FilterBar.vue
+++ b/src/frontend/src/components/FilterBar.vue
@@ -24,7 +24,7 @@
         <label for="filter-subtema" class="filter-label">Subtema</label>
         <select id="filter-subtema" v-model="local.subtema" class="filter-select" @change="emitir">
           <option value="">Todos</option>
-          <option v-for="t in temas" :key="t" :value="t">{{ t }}</option>
+          <option v-for="t in temas" :key="t.nome" :value="t.nome">{{ t.nome }}</option>
         </select>
       </div>
 

--- a/src/frontend/src/components/ProposicaoCard.vue
+++ b/src/frontend/src/components/ProposicaoCard.vue
@@ -1,7 +1,7 @@
 <template>
   <article class="proposicao-card" @click="navegar" role="button" tabindex="0" @keydown.enter="navegar" @keydown.space.prevent="navegar">
     <div class="card-header">
-      <span class="card-tag" :title="'Código: ' + (id || 'N/D')">{{ id || 'N/D' }}</span>
+      <span class="card-tag" :title="'Código: ' + (codigo || 'N/D')">{{ codigo || 'N/D' }}</span>
       <StatusBadge :status="status || 'Em tramitação'" />
       <span v-if="subtema" class="card-subtema">{{ subtema }}</span>
     </div>
@@ -50,10 +50,20 @@ const props = defineProps({
   partido: String,
   data: String,
   status: String,
-  subtema: String
+  subtema: String,
+  siglaTipo: String,
+  numero: [String, Number],
+  ano: [String, Number]
 })
 
 const router = useRouter()
+
+const codigo = computed(() => {
+  if (props.siglaTipo && props.numero && props.ano) {
+    return `${props.siglaTipo} ${props.numero}/${props.ano}`
+  }
+  return props.id
+})
 
 const dataFormatada = computed(() => {
   if (!props.data) return ''

--- a/src/frontend/src/components/StatusBadge.vue
+++ b/src/frontend/src/components/StatusBadge.vue
@@ -16,7 +16,7 @@ const classe = computed(() => {
   const s = props.status?.toLowerCase() ?? ''
   if (s.includes('aprovado') || s.includes('sancionado')) return 'status--aprovado'
   if (s.includes('urgente') || s.includes('crítico')) return 'status--urgente'
-  if (s.includes('arquivado') || s.includes('retirado')) return 'status--arquivado'
+  if (s.includes('arquivado') || s.includes('retirado') || s.includes('encerrado')) return 'status--arquivado'
   return 'status--tramitacao'
 })
 </script>

--- a/src/frontend/src/views/BuscaView.vue
+++ b/src/frontend/src/views/BuscaView.vue
@@ -47,10 +47,13 @@
                 :id="p.id"
                 :titulo="p.titulo || p.ementa"
                 :autor="p.autor || p.nome_autor"
-                :partido="p.partido || p.sigla_partido"
+                :partido="partidoLabel(p)"
                 :data="p.data || p.data_apresentacao"
                 :status="p.status"
                 :subtema="p.subtema || p.categoria"
+                :sigla-tipo="p.sigla_tipo"
+                :numero="p.numero"
+                :ano="p.ano"
               />
             </div>
           </div>
@@ -82,6 +85,13 @@ import LoadingSpinner from '@/components/LoadingSpinner.vue'
 const store = useProposicoesStore()
 const buscaStore = useBuscaStore()
 const buscaFeita = ref(false)
+
+function partidoLabel(p) {
+  if (p.partido && typeof p.partido === 'object') {
+    return p.partido.sigla || p.partido.nome || ''
+  }
+  return p.partido || p.sigla_partido || ''
+}
 
 async function onFiltroMudou(filtros) {
   Object.assign(buscaStore.filtros, filtros)

--- a/src/frontend/src/views/DetalheView.vue
+++ b/src/frontend/src/views/DetalheView.vue
@@ -25,7 +25,7 @@
         <article class="proposicao-detalhe" aria-label="Detalhes da proposição">
           <header class="detalhe-header">
             <div class="detalhe-badges">
-              <span class="detalhe-codigo">{{ proposicao.id }}</span>
+              <span class="detalhe-codigo">{{ codigo }}</span>
               <StatusBadge :status="proposicao.status || 'Em tramitação'" />
               <span v-if="proposicao.subtema || proposicao.categoria" class="detalhe-subtema">
                 {{ proposicao.subtema || proposicao.categoria }}
@@ -41,7 +41,7 @@
             </div>
             <div class="meta-grupo">
               <span class="meta-label">Partido</span>
-              <span class="meta-valor">{{ proposicao.partido || proposicao.sigla_partido || '—' }}</span>
+              <span class="meta-valor">{{ partidoLabel || '—' }}</span>
             </div>
             <div class="meta-grupo">
               <span class="meta-label">Data de Apresentação</span>
@@ -108,6 +108,24 @@ const dataFormatada = computed(() => {
   const d = proposicao.value?.data || proposicao.value?.data_apresentacao
   if (!d) return 'Não informada'
   try { return new Date(d).toLocaleDateString('pt-BR') } catch { return d }
+})
+
+const partidoLabel = computed(() => {
+  const p = proposicao.value
+  if (!p) return ''
+  if (p.partido && typeof p.partido === 'object') {
+    return p.partido.sigla || p.partido.nome || ''
+  }
+  return p.partido || p.sigla_partido || ''
+})
+
+const codigo = computed(() => {
+  const p = proposicao.value
+  if (!p) return ''
+  if (p.sigla_tipo && p.numero && p.ano) {
+    return `${p.sigla_tipo} ${p.numero}/${p.ano}`
+  }
+  return p.id
 })
 
 function formatarData(d) {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Subtema, status Encerrado e código de proposição</h1>
<h2>O que foi feito</h2>
<p>Três bugs visuais e um bug de serialização foram corrigidos em componentes Vue. Todos os dados necessários já chegavam da API — nenhum endpoint ou contrato de backend foi alterado.</p>
<h2>Mudanças</h2>
<p><strong>FilterBar.vue</strong>
O <code>&lt;option&gt;</code> do select de subtema estava vinculado ao objeto inteiro (<code>t</code>), fazendo com que <code>filter-changed</code> emitisse <code>[object Object]</code> como valor do filtro. O backend recebia esse texto e o ILIKE nunca casava com nada — o filtro estava quebrado silenciosamente. Corrigido trocando <code>:value="t"</code> por <code>:value="t.nome"</code>.</p>
<p><strong>StatusBadge.vue</strong>
O status <code>Encerrado</code> não tinha mapeamento de cor e caía no fallback padrão, ficando visualmente idêntico a <code>Em tramitação</code>. Adicionado ao mesmo case/classe cinza já usado por <code>Arquivado</code>.</p>
<p><strong>ProposicaoCard.vue / DetalheView.vue</strong>
Cards e tela de detalhe exibiam o ID numérico interno do banco (ex: <code>2345678</code>) onde deveria aparecer o código legível (ex: <code>PL 1234/2023</code>). Os campos <code>sigla_tipo</code>, <code>numero</code> e <code>ano</code> já chegavam no response — só o template não os usava. O <code>id</code> continua sendo usado internamente para rota e chave de lista.</p>
<p><strong>BuscaView.vue / DetalheView.vue</strong>
Adicionado <code>partidoLabel</code> com fallback que lê tanto <code>partido.sigla</code> (objeto relacional) quanto <code>sigla_partido</code> (string), evitando que futuras correções no ETL causem <code>[object Object]</code> na exibição de partido. A causa raiz (<code>sigla_partido</code> vazio porque <code>siglaPartido</code> não está disponível na listagem da API da Câmara) é um problema de ETL registrado para fix futuro no backend.</p>
<h2>Arquivos alterados</h2>

Arquivo | Operação
-- | --
src/frontend/src/components/FilterBar.vue | Editado
src/frontend/src/components/StatusBadge.vue | Editado
src/frontend/src/components/ProposicaoCard.vue | Editado
src/frontend/src/views/DetalheView.vue | Editado
src/frontend/src/views/BuscaView.vue | Editado


<h2>⚠️ Merge coordenado com <code>fix/backend</code></h2>
<p>Esta branch consome o campo <code>subtemas</code> (array) que a branch <code>fix/backend</code> passa a retornar no serializer. Se <code>fix/backend</code> ainda não estiver mergeada, o card vai tentar iterar um campo <code>subtemas</code> que ainda não existe no response — pode causar erro silencioso ou ausência dos badges de subtema.</p>
<p><strong>Mergear <code>fix/backend</code> antes ou junto com esta branch.</strong></p>
<h2>Como testar</h2>
<pre><code class="language-bash">cd src/frontend
npm run dev
</code></pre>
<ol>
<li>Tela de busca → selecionar um subtema no filtro → lista deve filtrar corretamente</li>
<li>Qualquer card → verificar código no formato <code>PL 1234/2023</code> em vez de número</li>
<li>Proposição com status <code>Encerrado</code> → badge deve aparecer em cinza</li>
<li>Tela de detalhe → verificar código legível e ausência de <code>[object Object]</code> no partido</li>
</ol></body></html><!--EndFragment-->
</body>
</html>